### PR TITLE
Clean up type detritus

### DIFF
--- a/constraints.go
+++ b/constraints.go
@@ -312,8 +312,6 @@ func constraintCaret(v *Version, c *constraint) bool {
 	return true
 }
 
-type rwfunc func(i string) string
-
 var constraintRangeRegex *regexp.Regexp
 
 const cvRegex string = `v?([0-9|x|X|\*]+)(\.[0-9|x|X|\*]+)?(\.[0-9|x|X|\*]+)?` +


### PR DESCRIPTION
Just removes what appears to be an old type, accidentally left over from a previous refactor