### PR TITLE
Simplify strings.Lower() call

### DIFF
--- a/constraints.go
+++ b/constraints.go
@@ -321,8 +321,12 @@ const cvRegex string = `v?([0-9|x|X|\*]+)(\.[0-9|x|X|\*]+)?(\.[0-9|x|X|\*]+)?` +
 	`(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?`
 
 func isX(x string) bool {
-	l := strings.ToLower(x)
-	return l == "x" || l == "*"
+	switch x {
+	case "x", "*", "X":
+		return true
+	default:
+		return false
+	}
 }
 
 func rewriteRange(i string) string {


### PR DESCRIPTION
Totally just a nit, but since it's only matching on the three characters, should be able to get away with this simple switch, no?