### PR TITLE
Strings are not the fastpath

### DIFF
--- a/version.go
+++ b/version.go
@@ -152,12 +152,6 @@ func (v *Version) Equal(o *Version) bool {
 // Versions are compared by X.Y.Z. Build metadata is ignored. Prerelease is
 // lower than the version without a prerelease.
 func (v *Version) Compare(o *Version) int {
-
-	// Fastpath if both versions are the same.
-	if v.String() == o.String() {
-		return 0
-	}
-
 	// Compare the major, minor, and patch version for differences. If a
 	// difference is found return the comparison.
 	if d := compareSegment(v.Major(), o.Major()); d != 0 {


### PR DESCRIPTION
This pulls over a commit from #7 , because strings are not the fastpath. This one change makes a crazy amount of difference:

![notfastpath](https://cloud.githubusercontent.com/assets/21599/14115074/8e323c6a-f5a7-11e5-86d5-c747b652cfc9.png)

With absolute numbers, that's:
```
benchmark                                  old ns/op     new ns/op     delta
BenchmarkCheckVersionRange-8               1987          22.1          -98.89%
BenchmarkCheckVersionUnion-8               2047          31.2          -98.48%
BenchmarkValidateVersionRange-8            1998          30.7          -98.46%
BenchmarkCheckVersionCaret-8               1000          17.7          -98.23%
BenchmarkCheckVersionTilde-8               1032          19.1          -98.15%
BenchmarkCheckVersionUnary-8               1012          19.8          -98.04%
BenchmarkValidateVersionCaret-8            1006          25.3          -97.49%
BenchmarkValidateVersionTilde-8            1023          27.6          -97.30%
BenchmarkValidateVersionUnary-8            1034          29.0          -97.20%
BenchmarkCheckVersionWildcard-8            1054          42.0          -96.02%
BenchmarkValidateVersionWildcard-8         1086          50.5          -95.35%
BenchmarkValidateVersionRangeFail-8        3278          1238          -62.23%
BenchmarkValidateVersionUnion-8            3340          1336          -60.00%
BenchmarkValidateVersionTildeFail-8        2294          1257          -45.20%
BenchmarkValidateVersionCaretFail-8        2288          1272          -44.41%
BenchmarkValidateVersionUnaryFail-8        2266          1274          -43.78%
BenchmarkValidateVersionUnionFail-8        4627          2610          -43.59%
BenchmarkValidateVersionWildcardFail-8     2325          1314          -43.48%
```

And the memory allocation:
```
BenchmarkCheckVersionUnary-8               10             0              -100.00%
BenchmarkCheckVersionTilde-8               10             0              -100.00%
BenchmarkCheckVersionCaret-8               10             0              -100.00%
BenchmarkCheckVersionWildcard-8            10             0              -100.00%
BenchmarkCheckVersionRange-8               20             0              -100.00%
BenchmarkCheckVersionUnion-8               20             0              -100.00%
BenchmarkValidateVersionUnary-8            10             0              -100.00%
BenchmarkValidateVersionUnaryFail-8        20             10             -50.00%
BenchmarkValidateVersionTilde-8            10             0              -100.00%
BenchmarkValidateVersionTildeFail-8        20             10             -50.00%
BenchmarkValidateVersionCaret-8            10             0              -100.00%
BenchmarkValidateVersionCaretFail-8        20             10             -50.00%
BenchmarkValidateVersionWildcard-8         10             0              -100.00%
BenchmarkValidateVersionWildcardFail-8     20             10             -50.00%
BenchmarkValidateVersionRange-8            20             0              -100.00%
BenchmarkValidateVersionRangeFail-8        30             10             -66.67%
BenchmarkValidateVersionUnion-8            30             10             -66.67%
BenchmarkValidateVersionUnionFail-8        40             20             -50.00%
```

So yeah, drop to zero allocs, plus a two order of magnitude speedup. I'll worry about optimizing the errors to not actually evaluate strings over in #7, but avoiding string evaluation is the single most important performance change we can make.