### PR TITLE
Depointerize

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -3,7 +3,7 @@ package semver
 // Collection is a collection of Version instances and implements the sort
 // interface. See the sort package for more details.
 // https://golang.org/pkg/sort/
-type Collection []*Version
+type Collection []Version
 
 // Len returns the length of a collection. The number of Version instances
 // on the slice.

--- a/collection_test.go
+++ b/collection_test.go
@@ -15,7 +15,7 @@ func TestCollection(t *testing.T) {
 		"0.4.2",
 	}
 
-	vs := make([]*Version, len(raw))
+	vs := make([]Version, len(raw))
 	for i, r := range raw {
 		v, err := NewVersion(r)
 		if err != nil {

--- a/constraints.go
+++ b/constraints.go
@@ -54,7 +54,7 @@ type Constraint interface {
 
 	// Matches checks that a version satisfies the constraint. If it does not,
 	// an error is returned indcating the problem; if it does, the error is nil.
-	Matches(v *Version) error
+	Matches(v Version) error
 
 	// Intersect computes the intersection between the receiving Constraint and
 	// passed Constraint, and returns a new Constraint representing the result.
@@ -201,7 +201,7 @@ func Union(cg ...Constraint) Constraint {
 			return c
 		case none:
 			continue
-		case *Version:
+		case Version:
 			//if tc != nil {
 			//heap.Push(&real, tc)
 			//}
@@ -233,9 +233,9 @@ func Union(cg ...Constraint) Constraint {
 
 		last := nuc[len(nuc)-1]
 		switch lt := last.(type) {
-		case *Version:
+		case Version:
 			switch ct := c.(type) {
-			case *Version:
+			case Version:
 				// Two versions in a row; only append if they're not equal
 				if !lt.Equal(ct) {
 					nuc = append(nuc, ct)
@@ -257,7 +257,7 @@ func Union(cg ...Constraint) Constraint {
 			}
 		case rangeConstraint:
 			switch ct := c.(type) {
-			case *Version:
+			case Version:
 				// Last was range, current is version. constraintList sort invariants guarantee
 				// that the version will be greater than the min, so we have to
 				// determine if the version is less than the max. If it is, we

--- a/constraints_test.go
+++ b/constraints_test.go
@@ -81,8 +81,8 @@ func constraintEq(c1, c2 Constraint) bool {
 			return false
 		}
 		return true
-	case *Version:
-		if tc2, ok := c2.(*Version); ok {
+	case Version:
+		if tc2, ok := c2.(Version); ok {
 			return tc1.Equal(tc2)
 		}
 		return false
@@ -136,8 +136,8 @@ func constraintEq(c1, c2 Constraint) bool {
 }
 
 // newV is a helper to create a new Version object.
-func newV(major, minor, patch uint64) *Version {
-	return &Version{
+func newV(major, minor, patch uint64) Version {
+	return Version{
 		major: major,
 		minor: minor,
 		patch: patch,
@@ -267,14 +267,14 @@ func TestNewConstraint(t *testing.T) {
 			includeMax: false,
 		}, false},
 		{"!=1.4.0", rangeConstraint{
-			excl: []*Version{
+			excl: []Version{
 				newV(1, 4, 0),
 			},
 		}, false},
 		{">=1.1.0, !=1.4.0", rangeConstraint{
 			min:        newV(1, 1, 0),
 			includeMin: true,
-			excl: []*Version{
+			excl: []Version{
 				newV(1, 4, 0),
 			},
 		}, false},
@@ -604,7 +604,7 @@ func TestIsSuperset(t *testing.T) {
 
 	// isSupersetOf ignores excludes, so even though this would make rc[1] not a
 	// superset of rc[0] anymore, it should still say it is.
-	rc[1].excl = []*Version{
+	rc[1].excl = []Version{
 		newV(1, 5, 0),
 	}
 

--- a/constraints_test.go
+++ b/constraints_test.go
@@ -11,28 +11,34 @@ func TestParseConstraint(t *testing.T) {
 		{"*", Any(), false},
 		{">= 1.2", rangeConstraint{
 			min:        newV(1, 2, 0),
+			max:        Version{special: infiniteVersion},
 			includeMin: true,
 		}, false},
 		{"1.0", newV(1, 0, 0), false},
 		{"foo", nil, true},
 		{"<= 1.2", rangeConstraint{
+			min:        Version{special: zeroVersion},
 			max:        newV(1, 2, 0),
 			includeMax: true,
 		}, false},
 		{"=< 1.2", rangeConstraint{
+			min:        Version{special: zeroVersion},
 			max:        newV(1, 2, 0),
 			includeMax: true,
 		}, false},
 		{"=> 1.2", rangeConstraint{
 			min:        newV(1, 2, 0),
+			max:        Version{special: infiniteVersion},
 			includeMin: true,
 		}, false},
 		{"v1.2", newV(1, 2, 0), false},
 		{"=1.5", newV(1, 5, 0), false},
 		{"> 1.3", rangeConstraint{
 			min: newV(1, 3, 0),
+			max: Version{special: infiniteVersion},
 		}, false},
 		{"< 1.4.1", rangeConstraint{
+			min: Version{special: zeroVersion},
 			max: newV(1, 4, 1),
 		}, false},
 		{"~1.1.0", rangeConstraint{

--- a/constraints_test.go
+++ b/constraints_test.go
@@ -225,6 +225,7 @@ func TestNewConstraint(t *testing.T) {
 	}{
 		{">= 1.1", rangeConstraint{
 			min:        newV(1, 1, 0),
+			max:        Version{special: infiniteVersion},
 			includeMin: true,
 		}, false},
 		{"2.0", newV(2, 0, 0), false},
@@ -273,12 +274,15 @@ func TestNewConstraint(t *testing.T) {
 			includeMax: false,
 		}, false},
 		{"!=1.4.0", rangeConstraint{
+			min: Version{special: zeroVersion},
+			max: Version{special: infiniteVersion},
 			excl: []Version{
 				newV(1, 4, 0),
 			},
 		}, false},
 		{">=1.1.0, !=1.4.0", rangeConstraint{
 			min:        newV(1, 1, 0),
+			max:        Version{special: infiniteVersion},
 			includeMin: true,
 			excl: []Version{
 				newV(1, 4, 0),
@@ -536,10 +540,12 @@ func TestIsSuperset(t *testing.T) {
 			max: newV(2, 1, 0),
 		},
 		rangeConstraint{
+			min: Version{special: zeroVersion},
 			max: newV(1, 10, 0),
 		},
 		rangeConstraint{
 			min: newV(2, 0, 0),
+			max: Version{special: infiniteVersion},
 		},
 		rangeConstraint{
 			min:        newV(1, 2, 0),

--- a/error.go
+++ b/error.go
@@ -23,11 +23,11 @@ const (
 
 type MatchFailure interface {
 	error
-	Pair() (v *Version, c Constraint)
+	Pair() (v Version, c Constraint)
 }
 
 type RangeMatchFailure struct {
-	v   *Version
+	v   Version
 	rc  rangeConstraint
 	typ int8
 }
@@ -36,19 +36,19 @@ func (rce RangeMatchFailure) Error() string {
 	return fmt.Sprintf(rangeErrs[rce.typ], rce.v, rce.rc)
 }
 
-func (rce RangeMatchFailure) Pair() (v *Version, r Constraint) {
+func (rce RangeMatchFailure) Pair() (v Version, r Constraint) {
 	return rce.v, rce.rc
 }
 
 type VersionMatchFailure struct {
-	v, other *Version
+	v, other Version
 }
 
 func (vce VersionMatchFailure) Error() string {
 	return fmt.Sprintf("%s is not equal to %s", vce.v, vce.other)
 }
 
-func (vce VersionMatchFailure) Pair() (v *Version, r Constraint) {
+func (vce VersionMatchFailure) Pair() (v Version, r Constraint) {
 	return vce.v, vce.other
 }
 

--- a/magic.go
+++ b/magic.go
@@ -18,7 +18,7 @@ func (any) String() string {
 
 // Matches checks that a version satisfies the constraint. As all versions
 // satisfy Any, this always returns nil.
-func (any) Matches(v *Version) error {
+func (any) Matches(v Version) error {
 	return nil
 }
 
@@ -61,7 +61,7 @@ func (none) String() string {
 
 // Matches checks that a version satisfies the constraint. As no version can
 // satisfy None, this always fails (returns an error).
-func (none) Matches(v *Version) error {
+func (none) Matches(v Version) error {
 	return noneErr
 }
 

--- a/parse.go
+++ b/parse.go
@@ -125,6 +125,8 @@ func expandTilde(v Version, wildMinor bool) Constraint {
 func expandNeq(v Version, wildMinor, wildPatch bool) Constraint {
 	if !(wildMinor || wildPatch) {
 		return rangeConstraint{
+			min:  Version{special: zeroVersion},
+			max:  Version{special: infiniteVersion},
 			excl: []Version{v},
 		}
 	}
@@ -132,6 +134,7 @@ func expandNeq(v Version, wildMinor, wildPatch bool) Constraint {
 	// Create the low range with no min, and the max as the floor admitted by
 	// the wildcard
 	lr := rangeConstraint{
+		min:        Version{special: zeroVersion},
 		max:        v,
 		includeMax: false,
 	}
@@ -152,6 +155,7 @@ func expandNeq(v Version, wildMinor, wildPatch bool) Constraint {
 
 	hr := rangeConstraint{
 		min:        minv,
+		max:        Version{special: infiniteVersion},
 		includeMin: true,
 	}
 
@@ -176,12 +180,14 @@ func expandGreater(v Version, wildMinor, wildPatch, eq bool) Constraint {
 		}
 		return rangeConstraint{
 			min:        v,
+			max:        Version{special: infiniteVersion},
 			includeMin: true,
 		}
 	}
 
 	return rangeConstraint{
 		min:        v,
+		max:        Version{special: infiniteVersion},
 		includeMin: eq,
 	}
 }
@@ -200,12 +206,14 @@ func expandLess(v Version, wildMinor, wildPatch, eq bool) Constraint {
 			v.minor++
 		}
 		return rangeConstraint{
+			min:        Version{special: zeroVersion},
 			max:        v,
 			includeMax: false,
 		}
 	}
 
 	return rangeConstraint{
+		min:        Version{special: zeroVersion},
 		max:        v,
 		includeMax: eq,
 	}

--- a/parse.go
+++ b/parse.go
@@ -81,8 +81,8 @@ func parseConstraint(c string) (Constraint, error) {
 	}
 }
 
-func expandCaret(v *Version) Constraint {
-	maxv := &Version{
+func expandCaret(v Version) Constraint {
+	maxv := Version{
 		major: v.major + 1,
 		minor: 0,
 		patch: 0,
@@ -96,13 +96,13 @@ func expandCaret(v *Version) Constraint {
 	}
 }
 
-func expandTilde(v *Version, wildMinor bool) Constraint {
+func expandTilde(v Version, wildMinor bool) Constraint {
 	if wildMinor {
 		// When minor is wild on a tilde, behavior is same as caret
 		return expandCaret(v)
 	}
 
-	maxv := &Version{
+	maxv := Version{
 		major: v.major,
 		minor: v.minor + 1,
 		patch: 0,
@@ -122,10 +122,10 @@ func expandTilde(v *Version, wildMinor bool) Constraint {
 // (which is how we represent a disjoint set). If there are no wildcards, it
 // will expand to a rangeConstraint with no min or max, but having the one
 // exception.
-func expandNeq(v *Version, wildMinor, wildPatch bool) Constraint {
+func expandNeq(v Version, wildMinor, wildPatch bool) Constraint {
 	if !(wildMinor || wildPatch) {
 		return rangeConstraint{
-			excl: []*Version{v},
+			excl: []Version{v},
 		}
 	}
 
@@ -138,7 +138,7 @@ func expandNeq(v *Version, wildMinor, wildPatch bool) Constraint {
 
 	// The high range uses the derived version (bumped depending on where the
 	// wildcards were) as the min, and is inclusive
-	minv := &Version{
+	minv := Version{
 		major: v.major,
 		minor: v.minor,
 		patch: v.patch,
@@ -158,10 +158,10 @@ func expandNeq(v *Version, wildMinor, wildPatch bool) Constraint {
 	return Union(lr, hr)
 }
 
-func expandGreater(v *Version, wildMinor, wildPatch, eq bool) Constraint {
+func expandGreater(v Version, wildMinor, wildPatch, eq bool) Constraint {
 	if (wildMinor || wildPatch) && !eq {
 		// wildcards negate the meaning of prerelease and other info
-		v = &Version{
+		v = Version{
 			major: v.major,
 			minor: v.minor,
 			patch: v.patch,
@@ -186,10 +186,10 @@ func expandGreater(v *Version, wildMinor, wildPatch, eq bool) Constraint {
 	}
 }
 
-func expandLess(v *Version, wildMinor, wildPatch, eq bool) Constraint {
+func expandLess(v Version, wildMinor, wildPatch, eq bool) Constraint {
 	if eq && (wildMinor || wildPatch) {
 		// wildcards negate the meaning of prerelease and other info
-		v = &Version{
+		v = Version{
 			major: v.major,
 			minor: v.minor,
 			patch: v.patch,

--- a/range.go
+++ b/range.go
@@ -84,11 +84,11 @@ func (rc rangeConstraint) dup() rangeConstraint {
 }
 
 func (rc rangeConstraint) minIsZero() bool {
-	return rc.min == nil
+	return rc.min.special == zeroVersion
 }
 
 func (rc rangeConstraint) maxIsInf() bool {
-	return rc.max == nil
+	return rc.max.special == infiniteVersion
 }
 
 func (rc rangeConstraint) Intersect(c Constraint) Constraint {
@@ -204,12 +204,12 @@ func (rc rangeConstraint) Union(c Constraint) Constraint {
 		if oc.LessThan(rc.min) {
 			return unionConstraint{oc, rc.dup()}
 		}
-		if areEq(oc, rc.min) {
+		if oc.Equal(rc.min) {
 			ret := rc.dup()
 			ret.includeMin = true
 			return ret
 		}
-		if areEq(oc, rc.max) {
+		if oc.Equal(rc.max) {
 			ret := rc.dup()
 			ret.includeMax = true
 			return ret
@@ -457,7 +457,7 @@ func areAdjacent(c1, c2 Constraint) bool {
 		return false
 	}
 
-	if !areEq(rc1.max, rc2.min) {
+	if !rc1.max.Equal(rc2.min) {
 		return false
 	}
 
@@ -491,14 +491,3 @@ oloop:
 
 func (rangeConstraint) _private() {}
 func (rangeConstraint) _real()    {}
-
-func areEq(v1, v2 Version) bool {
-	if v1 == nil && v2 == nil {
-		return true
-	}
-
-	if v1 != nil && v2 != nil {
-		return v1.Equal(v2)
-	}
-	return false
-}

--- a/range.go
+++ b/range.go
@@ -7,12 +7,12 @@ import (
 )
 
 type rangeConstraint struct {
-	min, max               *Version
+	min, max               Version
 	includeMin, includeMax bool
-	excl                   []*Version
+	excl                   []Version
 }
 
-func (rc rangeConstraint) Matches(v *Version) error {
+func (rc rangeConstraint) Matches(v Version) error {
 	var fail bool
 
 	rce := RangeMatchFailure{
@@ -70,8 +70,8 @@ func (rc rangeConstraint) dup() rangeConstraint {
 		return rc
 	}
 
-	var excl []*Version
-	excl = make([]*Version, len(rc.excl))
+	var excl []Version
+	excl = make([]Version, len(rc.excl))
 	copy(excl, rc.excl)
 
 	return rangeConstraint{
@@ -99,7 +99,7 @@ func (rc rangeConstraint) Intersect(c Constraint) Constraint {
 		return None()
 	case unionConstraint:
 		return oc.Intersect(rc)
-	case *Version:
+	case Version:
 		if err := rc.Matches(oc); err != nil {
 			return None()
 		} else {
@@ -174,7 +174,7 @@ func (rc rangeConstraint) Union(c Constraint) Constraint {
 		return rc
 	case unionConstraint:
 		return Union(rc, oc)
-	case *Version:
+	case Version:
 		if err := rc.Matches(oc); err == nil {
 			return rc
 		} else if len(rc.excl) > 0 { // TODO (re)checking like this is wasteful
@@ -182,7 +182,7 @@ func (rc rangeConstraint) Union(c Constraint) Constraint {
 			// it and return that
 			for k, e := range rc.excl {
 				if e.Equal(oc) {
-					excl := make([]*Version, len(rc.excl)-1)
+					excl := make([]Version, len(rc.excl)-1)
 
 					if k == len(rc.excl)-1 {
 						copy(excl, rc.excl[:k])
@@ -472,10 +472,10 @@ func (rc rangeConstraint) MatchesAny(c Constraint) bool {
 	return true
 }
 
-func dedupeExcls(ex1, ex2 []*Version) []*Version {
+func dedupeExcls(ex1, ex2 []Version) []Version {
 	// TODO stupid inefficient, but these are really only ever going to be
 	// small, so not worth optimizing right now
-	var ret []*Version
+	var ret []Version
 oloop:
 	for _, e1 := range ex1 {
 		for _, e2 := range ex2 {
@@ -492,7 +492,7 @@ oloop:
 func (rangeConstraint) _private() {}
 func (rangeConstraint) _real()    {}
 
-func areEq(v1, v2 *Version) bool {
+func areEq(v1, v2 Version) bool {
 	if v1 == nil && v2 == nil {
 		return true
 	}

--- a/range.go
+++ b/range.go
@@ -233,7 +233,10 @@ func (rc rangeConstraint) Union(c Constraint) Constraint {
 			}
 
 			// There's at least some dupes, which are all we need to include
-			nc := rangeConstraint{}
+			nc := rangeConstraint{
+				min: Version{special: zeroVersion},
+				max: Version{special: infiniteVersion},
+			}
 			for _, e1 := range rc.excl {
 				for _, e2 := range oc.excl {
 					if e1.Equal(e2) {
@@ -264,7 +267,10 @@ func (rc rangeConstraint) Union(c Constraint) Constraint {
 
 		} else if rc.MatchesAny(oc) {
 			// Receiver and input overlap; form a new range accordingly.
-			nc := rangeConstraint{}
+			nc := rangeConstraint{
+				min: Version{special: zeroVersion},
+				max: Version{special: infiniteVersion},
+			}
 
 			// For efficiency, we simultaneously determine if either of the
 			// ranges are supersets of the other, while also selecting the min

--- a/set_ops_test.go
+++ b/set_ops_test.go
@@ -133,8 +133,10 @@ func TestRangeIntersection(t *testing.T) {
 	// Overlaps with nils
 	rc1 = rangeConstraint{
 		min: newV(1, 0, 0),
+		max: Version{special: infiniteVersion},
 	}
 	rc2 = rangeConstraint{
+		min: Version{special: zeroVersion},
 		max: newV(2, 2, 0),
 	}
 	result = rangeConstraint{
@@ -296,9 +298,11 @@ func TestRangeIntersection(t *testing.T) {
 	// Test min, and greater min
 	rc1 = rangeConstraint{
 		min: newV(1, 0, 0),
+		max: Version{special: infiniteVersion},
 	}
 	rc2 = rangeConstraint{
 		min:        newV(1, 5, 0),
+		max:        Version{special: infiniteVersion},
 		includeMin: true,
 	}
 
@@ -329,12 +333,16 @@ func TestRangeIntersection(t *testing.T) {
 
 	// Ensure pure excludes come through as they should
 	rc1 = rangeConstraint{
+		min: Version{special: zeroVersion},
+		max: Version{special: infiniteVersion},
 		excl: []Version{
 			newV(1, 6, 0),
 		},
 	}
 
 	rc2 = rangeConstraint{
+		min: Version{special: zeroVersion},
+		max: Version{special: infiniteVersion},
 		excl: []Version{
 			newV(1, 6, 0),
 			newV(1, 7, 0),
@@ -454,8 +462,10 @@ func TestRangeUnion(t *testing.T) {
 	// Overlaps with nils
 	rc1 = rangeConstraint{
 		min: newV(1, 0, 0),
+		max: Version{special: infiniteVersion},
 	}
 	rc2 = rangeConstraint{
+		min: Version{special: zeroVersion},
 		max: newV(2, 2, 0),
 	}
 
@@ -469,6 +479,7 @@ func TestRangeUnion(t *testing.T) {
 	// Just one nil in overlap
 	rc1.max = newV(2, 0, 0)
 	result = rangeConstraint{
+		min: Version{special: zeroVersion},
 		max: newV(2, 2, 0),
 	}
 
@@ -483,6 +494,7 @@ func TestRangeUnion(t *testing.T) {
 	rc2.min = newV(1, 5, 0)
 	result = rangeConstraint{
 		min: newV(1, 0, 0),
+		max: Version{special: infiniteVersion},
 	}
 
 	if actual = rc1.Union(rc2); !constraintEq(actual, result) {
@@ -620,12 +632,16 @@ func TestRangeUnion(t *testing.T) {
 
 	// Ensure pure excludes come through as they should
 	rc1 = rangeConstraint{
+		min: Version{special: zeroVersion},
+		max: Version{special: infiniteVersion},
 		excl: []Version{
 			newV(1, 6, 0),
 		},
 	}
 
 	rc2 = rangeConstraint{
+		min: Version{special: zeroVersion},
+		max: Version{special: infiniteVersion},
 		excl: []Version{
 			newV(1, 6, 0),
 			newV(1, 7, 0),
@@ -640,6 +656,8 @@ func TestRangeUnion(t *testing.T) {
 	}
 
 	rc1 = rangeConstraint{
+		min: Version{special: zeroVersion},
+		max: Version{special: infiniteVersion},
 		excl: []Version{
 			newV(1, 5, 0),
 		},

--- a/set_ops_test.go
+++ b/set_ops_test.go
@@ -83,7 +83,7 @@ func TestRangeIntersection(t *testing.T) {
 	}
 
 	// now exclude just that version
-	rc1.excl = []*Version{v1}
+	rc1.excl = []Version{v1}
 	if actual = rc1.Intersect(v1); !IsNone(actual) {
 		t.Errorf("Intersection of version with range having specific exclude for that version should produce None; got %q", actual)
 	}
@@ -257,7 +257,7 @@ func TestRangeIntersection(t *testing.T) {
 	rc1 = rangeConstraint{
 		min: newV(1, 5, 0),
 		max: newV(2, 0, 0),
-		excl: []*Version{
+		excl: []Version{
 			newV(1, 6, 0),
 		},
 	}
@@ -281,7 +281,7 @@ func TestRangeIntersection(t *testing.T) {
 	rc2 = rangeConstraint{
 		min: newV(1, 0, 0),
 		max: newV(3, 0, 0),
-		excl: []*Version{
+		excl: []Version{
 			newV(1, 1, 0),
 		},
 	}
@@ -329,13 +329,13 @@ func TestRangeIntersection(t *testing.T) {
 
 	// Ensure pure excludes come through as they should
 	rc1 = rangeConstraint{
-		excl: []*Version{
+		excl: []Version{
 			newV(1, 6, 0),
 		},
 	}
 
 	rc2 = rangeConstraint{
-		excl: []*Version{
+		excl: []Version{
 			newV(1, 6, 0),
 			newV(1, 7, 0),
 		},
@@ -379,7 +379,7 @@ func TestRangeUnion(t *testing.T) {
 
 	// now exclude just that version
 	rc2 := rc1.dup()
-	rc2.excl = []*Version{v1}
+	rc2.excl = []Version{v1}
 	if actual = rc2.Union(v1); !constraintEq(actual, rc1) {
 		t.Errorf("Union of version with range having specific exclude for that version should produce the range without that exclude; got %q", actual)
 	}
@@ -479,7 +479,7 @@ func TestRangeUnion(t *testing.T) {
 		t.Errorf("Got constraint %q, but expected %q", actual, result)
 	}
 
-	rc1.max = nil
+	rc1.max = Version{special: infiniteVersion}
 	rc2.min = newV(1, 5, 0)
 	result = rangeConstraint{
 		min: newV(1, 0, 0),
@@ -582,7 +582,7 @@ func TestRangeUnion(t *testing.T) {
 	rc1 = rangeConstraint{
 		min: newV(1, 5, 0),
 		max: newV(2, 0, 0),
-		excl: []*Version{
+		excl: []Version{
 			newV(1, 6, 0),
 		},
 	}
@@ -606,7 +606,7 @@ func TestRangeUnion(t *testing.T) {
 	rc2 = rangeConstraint{
 		min: newV(1, 0, 0),
 		max: newV(3, 0, 0),
-		excl: []*Version{
+		excl: []Version{
 			newV(1, 1, 0),
 		},
 	}
@@ -620,13 +620,13 @@ func TestRangeUnion(t *testing.T) {
 
 	// Ensure pure excludes come through as they should
 	rc1 = rangeConstraint{
-		excl: []*Version{
+		excl: []Version{
 			newV(1, 6, 0),
 		},
 	}
 
 	rc2 = rangeConstraint{
-		excl: []*Version{
+		excl: []Version{
 			newV(1, 6, 0),
 			newV(1, 7, 0),
 		},
@@ -640,7 +640,7 @@ func TestRangeUnion(t *testing.T) {
 	}
 
 	rc1 = rangeConstraint{
-		excl: []*Version{
+		excl: []Version{
 			newV(1, 5, 0),
 		},
 	}
@@ -738,7 +738,7 @@ func TestUnionIntersection(t *testing.T) {
 	}
 
 	// Ensure excludes carry as they should
-	rc1.excl = []*Version{newV(1, 5, 5)}
+	rc1.excl = []Version{newV(1, 5, 5)}
 	u1 = unionConstraint{rc1, rc2}
 	ur = unionConstraint{rc1, rc4}
 

--- a/union.go
+++ b/union.go
@@ -91,7 +91,7 @@ func (cl constraintList) Less(i, j int) bool {
 		case Version:
 			return tic.LessThan(tjc)
 		case rangeConstraint:
-			if tjc.hasZeroMin() {
+			if tjc.minIsZero() {
 				return false
 			}
 
@@ -105,7 +105,7 @@ func (cl constraintList) Less(i, j int) bool {
 	case rangeConstraint:
 		switch tjc := jc.(type) {
 		case Version:
-			if tic.hasZeroMin() {
+			if tic.minIsZero() {
 				return true
 			}
 
@@ -116,10 +116,10 @@ func (cl constraintList) Less(i, j int) bool {
 			}
 			return tic.min.LessThan(tjc)
 		case rangeConstraint:
-			if tic.hasZeroMin() {
+			if tic.minIsZero() {
 				return true
 			}
-			if tjc.hasZeroMin() {
+			if tjc.minIsZero() {
 				return false
 			}
 			return tic.min.LessThan(tjc.min)

--- a/union.go
+++ b/union.go
@@ -4,7 +4,7 @@ import "strings"
 
 type unionConstraint []realConstraint
 
-func (uc unionConstraint) Matches(v *Version) error {
+func (uc unionConstraint) Matches(v Version) error {
 	var uce MultiMatchFailure
 	for _, c := range uc {
 		if err := c.Matches(v); err == nil {
@@ -25,7 +25,7 @@ func (uc unionConstraint) Intersect(c2 Constraint) Constraint {
 		return None()
 	case any:
 		return uc
-	case *Version:
+	case Version:
 		return c2
 	case rangeConstraint:
 		other = append(other, tc2)
@@ -86,9 +86,9 @@ func (cl constraintList) Less(i, j int) bool {
 	ic, jc := cl[i], cl[j]
 
 	switch tic := ic.(type) {
-	case *Version:
+	case Version:
 		switch tjc := jc.(type) {
-		case *Version:
+		case Version:
 			return tic.LessThan(tjc)
 		case rangeConstraint:
 			if tjc.min == nil {
@@ -104,7 +104,7 @@ func (cl constraintList) Less(i, j int) bool {
 		}
 	case rangeConstraint:
 		switch tjc := jc.(type) {
-		case *Version:
+		case Version:
 			if tic.min == nil {
 				return true
 			}

--- a/union.go
+++ b/union.go
@@ -91,7 +91,7 @@ func (cl constraintList) Less(i, j int) bool {
 		case Version:
 			return tic.LessThan(tjc)
 		case rangeConstraint:
-			if tjc.min == nil {
+			if tjc.hasZeroMin() {
 				return false
 			}
 
@@ -105,7 +105,7 @@ func (cl constraintList) Less(i, j int) bool {
 	case rangeConstraint:
 		switch tjc := jc.(type) {
 		case Version:
-			if tic.min == nil {
+			if tic.hasZeroMin() {
 				return true
 			}
 
@@ -116,10 +116,10 @@ func (cl constraintList) Less(i, j int) bool {
 			}
 			return tic.min.LessThan(tjc)
 		case rangeConstraint:
-			if tic.min == nil {
+			if tic.hasZeroMin() {
 				return true
 			}
-			if tjc.min == nil {
+			if tjc.hasZeroMin() {
 				return false
 			}
 			return tic.min.LessThan(tjc.min)

--- a/version.go
+++ b/version.go
@@ -84,7 +84,7 @@ func NewVersion(v string) (Version, error) {
 			versionCache[v] = vcache{err: ErrInvalidSemVer}
 			versionCacheLock.Unlock()
 		}
-		return nil, ErrInvalidSemVer
+		return Version{}, ErrInvalidSemVer
 	}
 
 	sv := Version{
@@ -103,7 +103,7 @@ func NewVersion(v string) (Version, error) {
 			versionCacheLock.Unlock()
 		}
 
-		return nil, bvs
+		return Version{}, bvs
 	}
 	sv.major = temp
 
@@ -117,7 +117,7 @@ func NewVersion(v string) (Version, error) {
 				versionCacheLock.Unlock()
 			}
 
-			return nil, bvs
+			return Version{}, bvs
 		}
 		sv.minor = temp
 	} else {
@@ -134,7 +134,7 @@ func NewVersion(v string) (Version, error) {
 				versionCacheLock.Unlock()
 			}
 
-			return nil, bvs
+			return Version{}, bvs
 		}
 		sv.patch = temp
 	} else {
@@ -201,21 +201,11 @@ func (v Version) Metadata() string {
 
 // LessThan tests if one version is less than another one.
 func (v Version) LessThan(o Version) bool {
-	// If a nil version was passed, fail and bail out early.
-	if o == nil {
-		return false
-	}
-
 	return v.Compare(o) < 0
 }
 
 // GreaterThan tests if one version is greater than another one.
 func (v Version) GreaterThan(o Version) bool {
-	// If a nil version was passed, fail and bail out early.
-	if o == nil {
-		return false
-	}
-
 	return v.Compare(o) > 0
 }
 
@@ -223,11 +213,6 @@ func (v Version) GreaterThan(o Version) bool {
 // Note, versions can be equal with different metadata since metadata
 // is not considered part of the comparable version.
 func (v Version) Equal(o Version) bool {
-	// If a nil version was passed, fail and bail out early.
-	if o == nil {
-		return false
-	}
-
 	return v.Compare(o) == 0
 }
 

--- a/version.go
+++ b/version.go
@@ -35,7 +35,7 @@ var versionCache = make(map[string]vcache)
 var versionCacheLock sync.RWMutex
 
 type vcache struct {
-	v   *Version
+	v   Version
 	err error
 }
 
@@ -58,7 +58,7 @@ func init() {
 
 // NewVersion parses a given version and returns an instance of Version or
 // an error if unable to parse the version.
-func NewVersion(v string) (*Version, error) {
+func NewVersion(v string) (Version, error) {
 	if CacheVersions {
 		versionCacheLock.RLock()
 		if sv, exists := versionCache[v]; exists {
@@ -78,7 +78,7 @@ func NewVersion(v string) (*Version, error) {
 		return nil, ErrInvalidSemVer
 	}
 
-	sv := &Version{
+	sv := Version{
 		metadata: m[8],
 		pre:      m[5],
 		original: v,
@@ -146,7 +146,7 @@ func NewVersion(v string) (*Version, error) {
 // See the Original() method to retrieve the original value. Semantic Versions
 // don't contain a leading v per the spec. Instead it's optional on
 // impelementation.
-func (v *Version) String() string {
+func (v Version) String() string {
 	var buf bytes.Buffer
 
 	fmt.Fprintf(&buf, "%d.%d.%d", v.major, v.minor, v.patch)
@@ -161,7 +161,7 @@ func (v *Version) String() string {
 }
 
 // Original returns the original value passed in to be parsed.
-func (v *Version) Original() string {
+func (v Version) Original() string {
 	return v.original
 }
 
@@ -181,17 +181,17 @@ func (v *Version) Patch() uint64 {
 }
 
 // Prerelease returns the pre-release version.
-func (v *Version) Prerelease() string {
+func (v Version) Prerelease() string {
 	return v.pre
 }
 
 // Metadata returns the metadata on the version.
-func (v *Version) Metadata() string {
+func (v Version) Metadata() string {
 	return v.metadata
 }
 
 // LessThan tests if one version is less than another one.
-func (v *Version) LessThan(o *Version) bool {
+func (v Version) LessThan(o Version) bool {
 	// If a nil version was passed, fail and bail out early.
 	if o == nil {
 		return false
@@ -201,7 +201,7 @@ func (v *Version) LessThan(o *Version) bool {
 }
 
 // GreaterThan tests if one version is greater than another one.
-func (v *Version) GreaterThan(o *Version) bool {
+func (v Version) GreaterThan(o Version) bool {
 	// If a nil version was passed, fail and bail out early.
 	if o == nil {
 		return false
@@ -213,7 +213,7 @@ func (v *Version) GreaterThan(o *Version) bool {
 // Equal tests if two versions are equal to each other.
 // Note, versions can be equal with different metadata since metadata
 // is not considered part of the comparable version.
-func (v *Version) Equal(o *Version) bool {
+func (v Version) Equal(o Version) bool {
 	// If a nil version was passed, fail and bail out early.
 	if o == nil {
 		return false
@@ -227,7 +227,7 @@ func (v *Version) Equal(o *Version) bool {
 //
 // Versions are compared by X.Y.Z. Build metadata is ignored. Prerelease is
 // lower than the version without a prerelease.
-func (v *Version) Compare(o *Version) int {
+func (v Version) Compare(o Version) int {
 	// Compare the major, minor, and patch version for differences. If a
 	// difference is found return the comparison.
 	if d := compareSegment(v.Major(), o.Major()); d != 0 {
@@ -257,7 +257,7 @@ func (v *Version) Compare(o *Version) int {
 	return comparePrerelease(ps, po)
 }
 
-func (v *Version) Matches(v2 *Version) error {
+func (v Version) Matches(v2 Version) error {
 	if v.Equal(v2) {
 		return nil
 	}
@@ -265,8 +265,8 @@ func (v *Version) Matches(v2 *Version) error {
 	return VersionMatchFailure{v: v, other: v2}
 }
 
-func (v *Version) MatchesAny(c Constraint) bool {
-	if v2, ok := c.(*Version); ok {
+func (v Version) MatchesAny(c Constraint) bool {
+	if v2, ok := c.(Version); ok {
 		return v.Equal(v2)
 	} else {
 		// The other implementations all have specific handling for this; fall
@@ -275,8 +275,8 @@ func (v *Version) MatchesAny(c Constraint) bool {
 	}
 }
 
-func (v *Version) Intersect(c Constraint) Constraint {
-	if v2, ok := c.(*Version); ok {
+func (v Version) Intersect(c Constraint) Constraint {
+	if v2, ok := c.(Version); ok {
 		if v.Equal(v2) {
 			return v
 		}
@@ -286,8 +286,8 @@ func (v *Version) Intersect(c Constraint) Constraint {
 	return c.Intersect(v)
 }
 
-func (v *Version) Union(c Constraint) Constraint {
-	if v2, ok := c.(*Version); ok && v.Equal(v2) {
+func (v Version) Union(c Constraint) Constraint {
+	if v2, ok := c.(Version); ok && v.Equal(v2) {
 		return v
 	} else {
 		return Union(v, c)

--- a/version_test.go
+++ b/version_test.go
@@ -180,6 +180,33 @@ func TestCompare(t *testing.T) {
 			)
 		}
 	}
+
+	// One-off tests for special version comparisons
+	zero := Version{special: zeroVersion}
+	inf := Version{special: infiniteVersion}
+
+	if zero.Compare(inf) != -1 {
+		t.Error("Zero version should always be less than infinite version")
+	}
+	if zero.Compare(zero) != 0 {
+		t.Error("Zero version should equal itself")
+	}
+	if inf.Compare(zero) != 1 {
+		t.Error("Infinite version should always be greater than zero version")
+	}
+	if inf.Compare(inf) != 0 {
+		t.Error("Infinite version should equal itself")
+	}
+
+	// Need to work vs. a normal version, too.
+	v := Version{}
+
+	if zero.Compare(v) != -1 {
+		t.Error("Zero version should always be less than any normal version")
+	}
+	if inf.Compare(v) != 1 {
+		t.Error("Infinite version should always be greater than any normal version")
+	}
 }
 
 func TestLessThan(t *testing.T) {


### PR DESCRIPTION
This PR converts `*Version` to `Version` in all places, and introduces corresponding sentinel values for zero and infinity to act at the lower and upper bound of ranges.

very much WIP, i'm not happy with how the sentinels work (per discussion in #25 )