### PR TITLE
Fixed #34: Simple range syntax requires a space

### DIFF
--- a/constraints.go
+++ b/constraints.go
@@ -129,7 +129,7 @@ func init() {
 		cvRegex))
 
 	constraintRangeRegex = regexp.MustCompile(fmt.Sprintf(
-		`\s*(%s)\s*-\s*(%s)\s*`,
+		`\s*(%s)\s+-\s+(%s)\s*`,
 		cvRegex, cvRegex))
 }
 

--- a/constraints_test.go
+++ b/constraints_test.go
@@ -107,12 +107,13 @@ func TestNewConstraint(t *testing.T) {
 	}{
 		{">= 1.1", 1, 1, false},
 		{"2.0", 1, 1, false},
+		{"v2.3.5-20161202202307-sha.e8fc5e5", 1, 1, false},
 		{">= bar", 0, 0, true},
 		{">= 1.2.3, < 2.0", 1, 2, false},
 		{">= 1.2.3, < 2.0 || => 3.0, < 4", 2, 2, false},
 
-		// The 3-4 should be broken into 2 by the range rewriting
-		{"3-4 || => 3.0, < 4", 2, 2, false},
+		// The 3 - 4 should be broken into 2 by the range rewriting
+		{"3 - 4 || => 3.0, < 4", 2, 2, false},
 	}
 
 	for _, tc := range tests {
@@ -243,9 +244,9 @@ func TestRewriteRange(t *testing.T) {
 		c  string
 		nc string
 	}{
-		{"2-3", ">= 2, <= 3"},
-		{"2-3, 2-3", ">= 2, <= 3,>= 2, <= 3"},
-		{"2-3, 4.0.0-5.1", ">= 2, <= 3,>= 4.0.0, <= 5.1"},
+		{"2 - 3", ">= 2, <= 3"},
+		{"2 - 3, 2 - 3", ">= 2, <= 3,>= 2, <= 3"},
+		{"2 - 3, 4.0.0 - 5.1", ">= 2, <= 3,>= 4.0.0, <= 5.1"},
 	}
 
 	for _, tc := range tests {
@@ -418,7 +419,7 @@ func TestConstraintsValidate(t *testing.T) {
 		{">=1.1, <2, !=1.2.3", "1.2.3", "1.2.3 is equal to 1.2.3"},
 		{">=1.1, <2, !=1.2.3 || > 3", "3.0.0", "3.0.0 is greater than or equal to 2"},
 		{">=1.1, <2, !=1.2.3 || > 3", "1.2.3", "1.2.3 is equal to 1.2.3"},
-		{"1.1-3", "4.3.2", "4.3.2 is greater than 3"},
+		{"1.1 - 3", "4.3.2", "4.3.2 is greater than 3"},
 		{"^1.1", "4.3.2", "4.3.2 does not have same major version as 1.1"},
 		{"^2.x", "1.1.1", "1.1.1 does not have same major version as 2.x"},
 		{"^1.x", "2.1.1", "2.1.1 does not have same major version as 1.x"},


### PR DESCRIPTION
A simple range requires a space. For example, 1.2.3-4.5.6 as a
range does not work because the - could signify a pre-release.
Instead this needs to be 1.2.3 - 4.5.6. That was the original
intent.