### PR TITLE
Strip out original prop on versions in constraints

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -49,6 +49,10 @@ func parseConstraint(c string) (Constraint, error) {
 		return nil, errors.New("constraint Parser Error")
 	}
 
+	// We never want to keep the "original" data in a constraint, and keeping it
+	// around can disrupt simple equality comparisons. So, strip it out.
+	v.original = ""
+
 	switch m[1] {
 	case "^":
 		// Caret always expands to a range


### PR DESCRIPTION
Constraints are logical constructs, not actual versions. As such, keeping around the "original" field data doesn't buy us anything. It does invite issues, though, in the form of simple equality comparisons not working when, say, the constituent versions on a range have slightly different values for "original."

So, this PR strips out "original" from all versions used in constraints.