### PR TITLE
Basic implementation & tests of implied carets

### DIFF
--- a/magic.go
+++ b/magic.go
@@ -16,6 +16,10 @@ func (any) String() string {
 	return "*"
 }
 
+func (any) ImpliedCaretString() string {
+	return "*"
+}
+
 // Matches checks that a version satisfies the constraint. As all versions
 // satisfy Any, this always returns nil.
 func (any) Matches(v Version) error {
@@ -56,6 +60,10 @@ func None() Constraint {
 }
 
 func (none) String() string {
+	return ""
+}
+
+func (none) ImpliedCaretString() string {
 	return ""
 }
 

--- a/parse.go
+++ b/parse.go
@@ -20,7 +20,7 @@ func rewriteRange(i string) string {
 	return o
 }
 
-func parseConstraint(c string) (Constraint, error) {
+func parseConstraint(c string, cbd bool) (Constraint, error) {
 	m := constraintRegex.FindStringSubmatch(c)
 	if m == nil {
 		return nil, fmt.Errorf("Malformed constraint: %s", c)
@@ -52,6 +52,12 @@ func parseConstraint(c string) (Constraint, error) {
 	// We never want to keep the "original" data in a constraint, and keeping it
 	// around can disrupt simple equality comparisons. So, strip it out.
 	v.original = ""
+
+	// If caret-by-default flag is on and there's no operator, convert the
+	// operator to a caret.
+	if cbd && m[1] == "" {
+		m[1] = "^"
+	}
 
 	switch m[1] {
 	case "^":

--- a/range.go
+++ b/range.go
@@ -375,6 +375,14 @@ func (rc rangeConstraint) isSupersetOf(rc2 rangeConstraint) bool {
 }
 
 func (rc rangeConstraint) String() string {
+	return rc.toString(false)
+}
+
+func (rc rangeConstraint) ImpliedCaretString() string {
+	return rc.toString(true)
+}
+
+func (rc rangeConstraint) toString(impliedCaret bool) string {
 	var pieces []string
 
 	// We need to trigger the standard verbose handling from various points, so
@@ -398,7 +406,14 @@ func (rc rangeConstraint) String() string {
 	}
 
 	// Handle the possibility that we might be able to express the range
-	// with a carat or tilde, as we prefer those forms.
+	// with a caret or tilde, as we prefer those forms.
+	var caretstr string
+	if impliedCaret {
+		caretstr = "%s"
+	} else {
+		caretstr = "^%s"
+	}
+
 	switch {
 	case rc.minIsZero() && rc.maxIsInf():
 		// This if is internal because it's useful to know for the other cases
@@ -409,13 +424,13 @@ func (rc rangeConstraint) String() string {
 			return "*"
 		}
 	case rc.minIsZero(), rc.includeMax, !rc.includeMin:
-		// tilde and carat could never apply here
+		// tilde and caret could never apply here
 		noshort()
-	case !rc.maxIsInf() && rc.max.Minor() == 0 && rc.max.Patch() == 0: // basic carat
+	case !rc.maxIsInf() && rc.max.Minor() == 0 && rc.max.Patch() == 0: // basic caret
 		if rc.min.Major() == rc.max.Major()-1 && rc.min.Major() != 0 {
-			pieces = append(pieces, fmt.Sprintf("^%s", rc.min))
+			pieces = append(pieces, fmt.Sprintf(caretstr, rc.min))
 		} else {
-			// range is too wide for carat, need standard operators
+			// range is too wide for caret, need standard operators
 			noshort()
 		}
 	case !rc.maxIsInf() && rc.max.Major() != 0 && rc.max.Patch() == 0: // basic tilde
@@ -426,10 +441,10 @@ func (rc rangeConstraint) String() string {
 			noshort()
 		}
 	case !rc.maxIsInf() && rc.max.Major() == 0 && rc.max.Patch() == 0 && rc.max.Minor() != 0:
-		// below 1.0.0, tilde is meaningless but carat is shifted to the
+		// below 1.0.0, tilde is meaningless but caret is shifted to the
 		// right (so it basically behaves the same as tilde does above 1.0.0)
 		if rc.min.Minor() == rc.max.Minor()-1 {
-			pieces = append(pieces, fmt.Sprintf("^%s", rc.min))
+			pieces = append(pieces, fmt.Sprintf(caretstr, rc.min))
 		} else {
 			noshort()
 		}

--- a/union.go
+++ b/union.go
@@ -71,6 +71,16 @@ func (uc unionConstraint) String() string {
 
 	return strings.Join(pieces, " || ")
 }
+
+func (uc unionConstraint) ImpliedCaretString() string {
+	var pieces []string
+	for _, c := range uc {
+		pieces = append(pieces, c.ImpliedCaretString())
+	}
+
+	return strings.Join(pieces, " || ")
+}
+
 func (unionConstraint) _private() {}
 
 type constraintList []realConstraint

--- a/version.go
+++ b/version.go
@@ -157,9 +157,27 @@ func NewVersion(v string) (Version, error) {
 // don't contain a leading v per the spec. Instead it's optional on
 // impelementation.
 func (v Version) String() string {
+	return v.toString(false)
+}
+
+// ImpliedCaretString follows the same rules as String(), but in accordance with
+// the Constraint interface will always print a leading "=", as all Versions,
+// when acting as a Constraint, act as exact matches.
+func (v Version) ImpliedCaretString() string {
+	return v.toString(true)
+}
+
+func (v Version) toString(ic bool) string {
 	var buf bytes.Buffer
 
-	fmt.Fprintf(&buf, "%d.%d.%d", v.major, v.minor, v.patch)
+	var base string
+	if ic {
+		base = "=%d.%d.%d"
+	} else {
+		base = "%d.%d.%d"
+	}
+
+	fmt.Fprintf(&buf, base, v.major, v.minor, v.patch)
 	if v.pre != "" {
 		fmt.Fprintf(&buf, "-%s", v.pre)
 	}


### PR DESCRIPTION
I elected to go the route of adding a method to the Constraint interface that allows the caller to decide how the constraint should be converted into a string. A bit of a kluge, but I think really the best of a bad set of options.

Fixes #41.