### PR TITLE
Make caret parsing behave like tilde below 1.0.0

### DIFF
--- a/constraints_test.go
+++ b/constraints_test.go
@@ -316,9 +316,13 @@ func TestConstraintsCheck(t *testing.T) {
 		check      bool
 	}{
 		{"*", "1.2.3", true},
-		{"~0.0.0", "1.2.3", false}, // npm allows this weird thing, but we don't
+		{"~0.0.0", "1.2.3", false},
+		{"0.x.x", "1.2.3", false},
+		{"0.0.x", "1.2.3", false},
 		{"~0.0.0", "0.1.9", false},
 		{"~0.0.0", "0.0.9", true},
+		{"^0.0.0", "0.0.9", true},
+		{"^0.0.0", "0.1.9", false}, // caret behaves like tilde below 1.0.0
 		{"= 2.0", "1.2.3", false},
 		{"= 2.0", "2.0.0", true},
 		{"4.1", "4.1.0", true},

--- a/parse.go
+++ b/parse.go
@@ -86,10 +86,12 @@ func parseConstraint(c string) (Constraint, error) {
 }
 
 func expandCaret(v Version) Constraint {
-	maxv := Version{
-		major: v.major + 1,
-		minor: 0,
-		patch: 0,
+	var maxv Version
+	// Caret behaves like tilde below 1.0.0
+	if v.major == 0 {
+		maxv.minor = v.minor + 1
+	} else {
+		maxv.major = v.major + 1
 	}
 
 	return rangeConstraint{


### PR DESCRIPTION
I just noticed that, while #30 defined stringify-time semantics for caret below 1.0.0 to be what we discussed in #21, it did not change the parse-time behavior accordingly. This fixes that - below 1.0.0, a caret behaves like a tilde.