### PR TITLE
Add special prerelease handling within ranges

### DIFF
--- a/constraints.go
+++ b/constraints.go
@@ -204,9 +204,7 @@ func Union(cg ...Constraint) Constraint {
 		case none:
 			continue
 		case Version:
-			//if tc != nil {
 			//heap.Push(&real, tc)
-			//}
 			real = append(real, tc)
 		case rangeConstraint:
 			//heap.Push(&real, tc)

--- a/constraints_test.go
+++ b/constraints_test.go
@@ -183,11 +183,15 @@ func TestConstraintCheck(t *testing.T) {
 		{">2.x", "3.0.0", true},
 		{">2.x", "2.9.9", false},
 		{">2.x", "1.9.9", false},
-		// TODO these are all pending the changes in #10
-		//{"<=2.x-beta1", "3.0.0-alpha2", false},
-		//{">2.x-beta1", "3.0.0-alpha2", true},
-		//{"<2.0.0", "2.0.0-alpha1", false},
-		//{"<=2.0.0", "2.0.0-alpha1", true},
+		{"<=2.x-alpha2", "3.0.0-alpha3", false},
+		{"<=2.0.0", "2.0.0-alpha1", false},
+		{">2.x-beta1", "3.0.0-alpha2", false},
+		{"^2.0.0", "3.0.0-alpha2", false},
+		{"^2.0.0", "2.0.0-alpha1", false},
+		{"^2.1.0-alpha1", "2.1.0-alpha2", true},  // allow prerelease match within same major/minor/patch
+		{"^2.1.0-alpha1", "2.1.1-alpha2", false}, // but ONLY within same major/minor/patch
+		{"^2.1.0-alpha3", "2.1.0-alpha2", false}, // still respect prerelease ordering
+		{"^2.0.0", "2.0.0-alpha2", false},        // and only if the min has a prerelease
 	}
 
 	for _, tc := range tests {

--- a/error.go
+++ b/error.go
@@ -11,6 +11,7 @@ var rangeErrs = [...]string{
 	"%s is greater than the maximum of %s",
 	"%s is greater than or equal to the maximum of %s",
 	"%s is specifically disallowed in %s",
+	"%s has prerelease data, so is omitted by the range %s",
 }
 
 const (
@@ -19,6 +20,7 @@ const (
 	rerrGT
 	rerrGTE
 	rerrNE
+	rerrPre
 )
 
 // MatchFailure is an interface for failures to find a Constraint match.

--- a/version.go
+++ b/version.go
@@ -353,7 +353,7 @@ func comparePrerelease(v, o string) int {
 
 	// Iterate over each part of the prereleases to compare the differences.
 	for i := 0; i < l; i++ {
-		// Since the lentgh of the parts can be different we need to create
+		// Since the length of the parts can be different we need to create
 		// a placeholder. This is to avoid out of bounds issues.
 		stemp := ""
 		if i < slen {
@@ -386,14 +386,14 @@ func comparePrePart(s, o string) int {
 	// When s or o are empty we can use the other in an attempt to determine
 	// the response.
 	if o == "" {
-		_, n := strconv.ParseInt(s, 10, 64)
+		_, n := strconv.ParseUint(s, 10, 64)
 		if n != nil {
 			return -1
 		}
 		return 1
 	}
 	if s == "" {
-		_, n := strconv.ParseInt(o, 10, 64)
+		_, n := strconv.ParseUint(o, 10, 64)
 		if n != nil {
 			return 1
 		}
@@ -404,4 +404,26 @@ func comparePrePart(s, o string) int {
 		return 1
 	}
 	return -1
+}
+
+func numPartsEq(v1, v2 Version) bool {
+	if v1.special != v2.special {
+		return false
+	}
+	if v1.special != notSpecial {
+		// If special fields are equal and not notSpecial, then the versions are
+		// necessarily equal, so their numeric parts are too.
+		return true
+	}
+
+	if v1.major != v2.major {
+		return false
+	}
+	if v1.minor != v2.minor {
+		return false
+	}
+	if v1.patch != v2.patch {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
Fixes #10.

I ended up not doing the LT/LTE differential at the top of ranges that Dart does (as I described in the issue). This is consistent with npm, and still probably a bit saner.