### PR TITLE
Fixed #57: number comparisons in prerelease

### DIFF
--- a/version.go
+++ b/version.go
@@ -394,8 +394,29 @@ func comparePrePart(s, o string) int {
 		return -1
 	}
 
-	if s > o {
+	// When comparing strings "99" is greater than "103". To handle
+	// cases like this we need to detect numbers and compare them.
+
+	oi, n1 := strconv.ParseInt(o, 10, 64)
+	si, n2 := strconv.ParseInt(s, 10, 64)
+
+	// The case where both are strings compare the strings
+	if n1 != nil && n2 != nil {
+		if s > o {
+			return 1
+		}
+		return -1
+	} else if n1 != nil {
+		// o is a string and s is a number
+		return -1
+	} else if n2 != nil {
+		// s is a string and o is a number
+		return 1
+	}
+	// Both are numbers
+	if si > oi {
 		return 1
 	}
 	return -1
+
 }

--- a/version_test.go
+++ b/version_test.go
@@ -226,6 +226,11 @@ func TestGreaterThan(t *testing.T) {
 		{"1.2.3", "1.5.1", false},
 		{"2.2.3", "1.5.1", true},
 		{"3.2-beta", "3.2-beta", false},
+		{"3.2.0-beta.1", "3.2.0-beta.5", false},
+		{"3.2-beta.4", "3.2-beta.2", true},
+		{"7.43.0-SNAPSHOT.99", "7.43.0-SNAPSHOT.103", false},
+		{"7.43.0-SNAPSHOT.FOO", "7.43.0-SNAPSHOT.103", true},
+		{"7.43.0-SNAPSHOT.99", "7.43.0-SNAPSHOT.BAR", false},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
String comparisons of "99" and "103" see "99" as greater. To handle
cases like this we attempt to turn them into integers and handle
comparisons so 99 is seen as less than 103.