### PR TITLE
Handle a version with a dash in the prerelease tag

### DIFF
--- a/constraints_test.go
+++ b/constraints_test.go
@@ -53,6 +53,12 @@ func TestParseConstraint(t *testing.T) {
 			includeMin: true,
 			includeMax: false,
 		}, false},
+		{"^1.1.0-12-abc123", rangeConstraint{
+			min:        Version{major: 1, minor: 1, patch: 0, pre: "12-abc123"},
+			max:        newV(2, 0, 0),
+			includeMin: true,
+			includeMax: false,
+		}, false},
 	}
 
 	for _, tc := range tests {
@@ -70,7 +76,7 @@ func TestParseConstraint(t *testing.T) {
 		}
 
 		if !constraintEq(tc.c, c) {
-			t.Errorf("Incorrect version found on %s", tc.in)
+			t.Errorf("%q produced constraint %q, but expected %q", tc.in, c, tc.c)
 		}
 	}
 }
@@ -331,6 +337,12 @@ func TestNewConstraintIC(t *testing.T) {
 			max:        newV(2, 0, 0),
 			includeMin: true,
 		}, false},
+		{"v1.1.0-12-abc123", rangeConstraint{
+			min:        Version{major: 1, minor: 1, patch: 0, pre: "12-abc123"},
+			max:        newV(2, 0, 0),
+			includeMin: true,
+			includeMax: false,
+		}, false},
 	}
 
 	for _, tc := range tests {
@@ -548,6 +560,7 @@ func TestRewriteRange(t *testing.T) {
 		{"2-3", ">= 2, <= 3"},
 		{"2-3, 2-3", ">= 2, <= 3,>= 2, <= 3"},
 		{"2-3, 4.0.0-5.1", ">= 2, <= 3,>= 4.0.0, <= 5.1"},
+		{"v2-3, 2-3", "v2-3,>= 2, <= 3"},
 	}
 
 	for _, tc := range tests {

--- a/parse.go
+++ b/parse.go
@@ -13,6 +13,9 @@ func rewriteRange(i string) string {
 	}
 	o := i
 	for _, v := range m {
+		if strings.HasPrefix(v[0], "v") && versionRegex.MatchString(v[0]) {
+			continue
+		}
 		t := fmt.Sprintf(">= %s, <= %s", v[1], v[11])
 		o = strings.Replace(o, v[0], t, 1)
 	}


### PR DESCRIPTION
When parsing a constraint, before converting dashes to a range, check if it is a valid version first. That way a version with multiple dashes, like `v1.0.0-12-abc123` isn't turned into a range of `1.0.0` to `12-abc123`.

Fixes #59.