### PR TITLE
Update major.minor.patch version for 64bit ints

### DIFF
--- a/version.go
+++ b/version.go
@@ -64,14 +64,14 @@ func NewVersion(v string) (*Version, error) {
 	}
 
 	var temp int64
-	temp, err := strconv.ParseInt(m[1], 10, 32)
+	temp, err := strconv.ParseInt(m[1], 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing version segment: %s", err)
 	}
 	sv.major = temp
 
 	if m[2] != "" {
-		temp, err = strconv.ParseInt(strings.TrimPrefix(m[2], "."), 10, 32)
+		temp, err = strconv.ParseInt(strings.TrimPrefix(m[2], "."), 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("Error parsing version segment: %s", err)
 		}
@@ -81,7 +81,7 @@ func NewVersion(v string) (*Version, error) {
 	}
 
 	if m[3] != "" {
-		temp, err = strconv.ParseInt(strings.TrimPrefix(m[3], "."), 10, 32)
+		temp, err = strconv.ParseInt(strings.TrimPrefix(m[3], "."), 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("Error parsing version segment: %s", err)
 		}

--- a/version_test.go
+++ b/version_test.go
@@ -34,6 +34,9 @@ func TestNewVersion(t *testing.T) {
 		{"v1.2.3-rc1-with-hypen", false},
 		{"1.2.3.4", true},
 		{"v1.2.3.4", true},
+		{"1.2.2147483648", false},
+		{"1.2147483648.3", false},
+		{"2147483648.3.0", false},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Update NewVersion to parse ints with a 64bit int size.

Version's major, minor and patch fields are all int64 but NewVersion was
parsing them with a 32bit bitsize, update this to 64bits.

This is useful when the patch number is a timestamp in the format:
yyMMddHHmmssSSS which produces numbers like 171003153320169

Add a test cases using 2147483648 (1 more than max 32bit int).