### PR TITLE
Fix unchecked error in example code

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -47,7 +47,7 @@ parts of the package.
         // Handle constraint not being parseable.
     }
 
-    v, _ := semver.NewVersion("1.3")
+    v, err := semver.NewVersion("1.3")
     if err != nil {
         // Handle version not being parseable.
     }


### PR DESCRIPTION
The example code for "Checking Version Constraints" failed to re-assign the `err` variable, leading to broken example code.