### PR TITLE
Clarify caret operator range for pre-1.0.0 dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ The caret (`^`) comparison operator is for major level changes. This is useful
 when comparisons of API versions as a major change is API breaking. For example,
 
 * `^1.2.3` is equivalent to `>= 1.2.3, < 2.0.0`
+* `^0.0.1` is equivalent to `>= 0.0.1, < 1.0.0`
 * `^1.2.x` is equivalent to `>= 1.2.0, < 2.0.0`
 * `^2.3` is equivalent to `>= 2.3, < 3`
 * `^2.x` is equivalent to `>= 2.0.0, < 3`

--- a/constraints_test.go
+++ b/constraints_test.go
@@ -354,6 +354,7 @@ func TestConstraintsValidate(t *testing.T) {
 		{"^1.x", "1.1.1", true},
 		{"^2.x", "1.1.1", false},
 		{"^1.x", "2.1.1", false},
+		{"^0.0.1", "0.1.3", true},
 		{"~*", "2.1.1", true},
 		{"~1", "2.1.1", false},
 		{"~1", "1.3.5", true},


### PR DESCRIPTION
I couldn't find any documentation on the behaviour of the caret operator for pre-1.0.0 dependencies, and it wasn't immediately obvious that it would behave in the same way as for post-1.0.0 dependencies (mainly because in JS it doesn't).

This PR adds a pre-1.0.0 example to the readme and adds a test for the current behaviour.

This may have been discussed elsewhere, but in combination with`dep` using the caret operator by default, the current behaviour here is a little surprising. I can imaging users setting `version = "0.0.1"` in their `Gopkg.toml` and being surprised/unhappy to get `0.0.3`, which might include a host of breaking changes. Maybe that's better fixed in `dep` than here, though.