### PR TITLE
treat OR | as OR ||

### DIFF
--- a/constraints.go
+++ b/constraints.go
@@ -20,7 +20,8 @@ func NewConstraint(c string) (*Constraints, error) {
 	// Rewrite - ranges into a comparison operation.
 	c = rewriteRange(c)
 
-	ors := strings.Split(c, "||")
+	c = strings.Replace(c, "||", "|", -1)
+	ors := strings.Split(c, "|")
 	or := make([][]*constraint, len(ors))
 	for k, v := range ors {
 		cs := strings.Split(v, ",")

--- a/constraints_test.go
+++ b/constraints_test.go
@@ -124,6 +124,8 @@ func TestNewConstraint(t *testing.T) {
 		{">= bar", 0, 0, true},
 		{">= 1.2.3, < 2.0", 1, 2, false},
 		{">= 1.2.3, < 2.0 || => 3.0, < 4", 2, 2, false},
+		{"<1 || =2 | >3", 3, 1, false},
+		{"<1 | | >3", 0, 0, true},
 
 		// The 3 - 4 should be broken into 2 by the range rewriting
 		{"3 - 4 || => 3.0, < 4", 2, 2, false},


### PR DESCRIPTION
Some dependency system (like PHP composer) treat single pipes _OR_ the same as double pipes _OR_, probably to simplify the syntax because it's unlikely that anyone will use a pipe as a bitwise operator.  This little patch seems to do the trick in supporting the use of single pipe as a logical constraint.