### PR TITLE
Attempt at fixing failing case

### DIFF
--- a/constraints.go
+++ b/constraints.go
@@ -175,9 +175,15 @@ func parseConstraint(c string) (*constraint, error) {
 	if isX(m[3]) {
 		ver = "0.0.0"
 		dirty = true
-	} else if isX(strings.TrimPrefix(m[4], ".")) || m[4] == "" {
+	} else if isX(strings.TrimPrefix(m[4], ".")) {
 		minorDirty = true
 		dirty = true
+		ver = fmt.Sprintf("%s.0.0%s", m[3], m[6])
+	} else if m[4] == "" {
+		if m[1] == "" || m[1] == "~" {
+			minorDirty = true
+			dirty = true
+		}
 		ver = fmt.Sprintf("%s.0.0%s", m[3], m[6])
 	} else if isX(strings.TrimPrefix(m[5], ".")) {
 		dirty = true

--- a/constraints_test.go
+++ b/constraints_test.go
@@ -371,6 +371,7 @@ func TestConstraintsValidate(t *testing.T) {
 		{"~1.2.3", "1.3.2", false},
 		{"~1.1", "1.2.3", false},
 		{"~1.3", "2.4.5", false},
+		{"<11", "11.1.0", false},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
This is a somewhat blind attempt at fixing https://github.com/Masterminds/semver/issues/93

When a constraint string is a single major version number: `11` it shouldn't be considered "dirty" unless it is not paired with an "op"

`> 11`, `<= 11`, `^11`

The exception seems to be when a `~` is specified, but I'm not sure I understand why.