### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ parts of the package.
         // Handle constraint not being parseable.
     }
 
-    v, _ := semver.NewVersion("1.3")
+    v, err := semver.NewVersion("1.3")
     if err != nil {
         // Handle version not being parseable.
     }


### PR DESCRIPTION
Readme example shows rechecking same error instead of what is commented.