### PR TITLE
NewVersion now validates and CoerceNewVersion handles semver-ish

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -9,38 +9,54 @@ import (
 /* Constraint creation benchmarks */
 
 func benchNewConstraint(c string, b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, _ = semver.NewConstraint(c)
 	}
 }
 
 func BenchmarkNewConstraintUnary(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchNewConstraint("=2.0", b)
 }
 
 func BenchmarkNewConstraintTilde(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchNewConstraint("~2.0.0", b)
 }
 
 func BenchmarkNewConstraintCaret(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchNewConstraint("^2.0.0", b)
 }
 
 func BenchmarkNewConstraintWildcard(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchNewConstraint("1.x", b)
 }
 
 func BenchmarkNewConstraintRange(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchNewConstraint(">=2.1.x, <3.1.0", b)
 }
 
 func BenchmarkNewConstraintUnion(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchNewConstraint("~2.0.0 || =3.1.0", b)
 }
 
 /* Check benchmarks */
 
 func benchCheckVersion(c, v string, b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	version, _ := semver.NewVersion(v)
 	constraint, _ := semver.NewConstraint(c)
 
@@ -50,30 +66,44 @@ func benchCheckVersion(c, v string, b *testing.B) {
 }
 
 func BenchmarkCheckVersionUnary(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchCheckVersion("=2.0", "2.0.0", b)
 }
 
 func BenchmarkCheckVersionTilde(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchCheckVersion("~2.0.0", "2.0.5", b)
 }
 
 func BenchmarkCheckVersionCaret(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchCheckVersion("^2.0.0", "2.1.0", b)
 }
 
 func BenchmarkCheckVersionWildcard(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchCheckVersion("1.x", "1.4.0", b)
 }
 
 func BenchmarkCheckVersionRange(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchCheckVersion(">=2.1.x, <3.1.0", "2.4.5", b)
 }
 
 func BenchmarkCheckVersionUnion(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchCheckVersion("~2.0.0 || =3.1.0", "3.1.0", b)
 }
 
 func benchValidateVersion(c, v string, b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	version, _ := semver.NewVersion(v)
 	constraint, _ := semver.NewConstraint(c)
 
@@ -85,50 +115,74 @@ func benchValidateVersion(c, v string, b *testing.B) {
 /* Validate benchmarks, including fails */
 
 func BenchmarkValidateVersionUnary(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchValidateVersion("=2.0", "2.0.0", b)
 }
 
 func BenchmarkValidateVersionUnaryFail(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchValidateVersion("=2.0", "2.0.1", b)
 }
 
 func BenchmarkValidateVersionTilde(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchValidateVersion("~2.0.0", "2.0.5", b)
 }
 
 func BenchmarkValidateVersionTildeFail(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchValidateVersion("~2.0.0", "1.0.5", b)
 }
 
 func BenchmarkValidateVersionCaret(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchValidateVersion("^2.0.0", "2.1.0", b)
 }
 
 func BenchmarkValidateVersionCaretFail(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchValidateVersion("^2.0.0", "4.1.0", b)
 }
 
 func BenchmarkValidateVersionWildcard(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchValidateVersion("1.x", "1.4.0", b)
 }
 
 func BenchmarkValidateVersionWildcardFail(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchValidateVersion("1.x", "2.4.0", b)
 }
 
 func BenchmarkValidateVersionRange(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchValidateVersion(">=2.1.x, <3.1.0", "2.4.5", b)
 }
 
 func BenchmarkValidateVersionRangeFail(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchValidateVersion(">=2.1.x, <3.1.0", "1.4.5", b)
 }
 
 func BenchmarkValidateVersionUnion(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchValidateVersion("~2.0.0 || =3.1.0", "3.1.0", b)
 }
 
 func BenchmarkValidateVersionUnionFail(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchValidateVersion("~2.0.0 || =3.1.0", "3.1.1", b)
 }
 
@@ -140,18 +194,56 @@ func benchNewVersion(v string, b *testing.B) {
 	}
 }
 
+func benchCoerceNewVersion(v string, b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = semver.CoerceNewVersion(v)
+	}
+}
+
 func BenchmarkNewVersionSimple(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchNewVersion("1.0.0", b)
 }
 
+func BenchmarkCoerceNewVersionSimple(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	benchCoerceNewVersion("1.0.0", b)
+}
+
 func BenchmarkNewVersionPre(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchNewVersion("1.0.0-alpha", b)
 }
 
+func BenchmarkCoerceNewVersionPre(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	benchCoerceNewVersion("1.0.0-alpha", b)
+}
+
 func BenchmarkNewVersionMeta(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
 	benchNewVersion("1.0.0+metadata", b)
 }
 
+func BenchmarkCoerceNewVersionMeta(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	benchCoerceNewVersion("1.0.0+metadata", b)
+}
+
 func BenchmarkNewVersionMetaDash(b *testing.B) {
-	benchNewVersion("1.0.0+metadata-dash", b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	benchNewVersion("1.0.0-alpha.1+meta.data", b)
+}
+
+func BenchmarkCoerceNewVersionMetaDash(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	benchCoerceNewVersion("1.0.0-alpha.1+meta.data", b)
 }

--- a/collection.go
+++ b/collection.go
@@ -3,7 +3,7 @@ package semver
 // Collection is a collection of Version instances and implements the sort
 // interface. See the sort package for more details.
 // https://golang.org/pkg/sort/
-type Collection []*Version
+type Collection []Version
 
 // Len returns the length of a collection. The number of Version instances
 // on the slice.

--- a/collection_test.go
+++ b/collection_test.go
@@ -15,9 +15,9 @@ func TestCollection(t *testing.T) {
 		"0.4.2",
 	}
 
-	vs := make([]*Version, len(raw))
+	vs := make([]Version, len(raw))
 	for i, r := range raw {
-		v, err := NewVersion(r)
+		v, err := CoerceNewVersion(r)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}

--- a/constraints.go
+++ b/constraints.go
@@ -41,7 +41,7 @@ func NewConstraint(c string) (*Constraints, error) {
 }
 
 // Check tests if a version satisfies the constraints.
-func (cs Constraints) Check(v *Version) bool {
+func (cs Constraints) Check(v Version) bool {
 	// loop over the ORs and check the inner ANDs
 	for _, o := range cs.constraints {
 		joy := true
@@ -62,7 +62,7 @@ func (cs Constraints) Check(v *Version) bool {
 
 // Validate checks if a version satisfies a constraint. If not a slice of
 // reasons for the failure are returned in addition to a bool.
-func (cs Constraints) Validate(v *Version) (bool, []error) {
+func (cs Constraints) Validate(v Version) (bool, []error) {
 	// loop over the ORs and check the inner ANDs
 	var e []error
 	for _, o := range cs.constraints {
@@ -143,7 +143,7 @@ type constraint struct {
 
 	// The version used in the constraint check. For example, if a constraint
 	// is '<= 2.0.0' the con a version instance representing 2.0.0.
-	con *Version
+	con Version
 
 	// The original parsed version (e.g., 4.x from != 4.x)
 	orig string
@@ -155,11 +155,11 @@ type constraint struct {
 }
 
 // Check if a version meets the constraint
-func (c *constraint) check(v *Version) bool {
+func (c *constraint) check(v Version) bool {
 	return c.function(v, c)
 }
 
-type cfunc func(v *Version, c *constraint) bool
+type cfunc func(v Version, c *constraint) bool
 
 func parseConstraint(c string) (*constraint, error) {
 	m := constraintRegex.FindStringSubmatch(c)
@@ -185,7 +185,7 @@ func parseConstraint(c string) (*constraint, error) {
 		ver = fmt.Sprintf("%s%s.0%s", m[3], m[4], m[6])
 	}
 
-	con, err := NewVersion(ver)
+	con, err := CoerceNewVersion(ver)
 	if err != nil {
 
 		// The constraintRegex should catch any regex parsing errors. So,
@@ -206,7 +206,7 @@ func parseConstraint(c string) (*constraint, error) {
 }
 
 // Constraint functions
-func constraintNotEqual(v *Version, c *constraint) bool {
+func constraintNotEqual(v Version, c *constraint) bool {
 	if c.dirty {
 
 		// If there is a pre-release on the version but the constraint isn't looking
@@ -231,7 +231,7 @@ func constraintNotEqual(v *Version, c *constraint) bool {
 	return !v.Equal(c.con)
 }
 
-func constraintGreaterThan(v *Version, c *constraint) bool {
+func constraintGreaterThan(v Version, c *constraint) bool {
 
 	// If there is a pre-release on the version but the constraint isn't looking
 	// for them assume that pre-releases are not compatible. See issue 21 for
@@ -243,7 +243,7 @@ func constraintGreaterThan(v *Version, c *constraint) bool {
 	return v.Compare(c.con) == 1
 }
 
-func constraintLessThan(v *Version, c *constraint) bool {
+func constraintLessThan(v Version, c *constraint) bool {
 	// If there is a pre-release on the version but the constraint isn't looking
 	// for them assume that pre-releases are not compatible. See issue 21 for
 	// more details.
@@ -264,7 +264,7 @@ func constraintLessThan(v *Version, c *constraint) bool {
 	return true
 }
 
-func constraintGreaterThanEqual(v *Version, c *constraint) bool {
+func constraintGreaterThanEqual(v Version, c *constraint) bool {
 
 	// If there is a pre-release on the version but the constraint isn't looking
 	// for them assume that pre-releases are not compatible. See issue 21 for
@@ -276,7 +276,7 @@ func constraintGreaterThanEqual(v *Version, c *constraint) bool {
 	return v.Compare(c.con) >= 0
 }
 
-func constraintLessThanEqual(v *Version, c *constraint) bool {
+func constraintLessThanEqual(v Version, c *constraint) bool {
 	// If there is a pre-release on the version but the constraint isn't looking
 	// for them assume that pre-releases are not compatible. See issue 21 for
 	// more details.
@@ -303,7 +303,7 @@ func constraintLessThanEqual(v *Version, c *constraint) bool {
 // ~1.2, ~1.2.x, ~>1.2, ~>1.2.x --> >=1.2.0, <1.3.0
 // ~1.2.3, ~>1.2.3 --> >=1.2.3, <1.3.0
 // ~1.2.0, ~>1.2.0 --> >=1.2.0, <1.3.0
-func constraintTilde(v *Version, c *constraint) bool {
+func constraintTilde(v Version, c *constraint) bool {
 	// If there is a pre-release on the version but the constraint isn't looking
 	// for them assume that pre-releases are not compatible. See issue 21 for
 	// more details.
@@ -335,7 +335,7 @@ func constraintTilde(v *Version, c *constraint) bool {
 
 // When there is a .x (dirty) status it automatically opts in to ~. Otherwise
 // it's a straight =
-func constraintTildeOrEqual(v *Version, c *constraint) bool {
+func constraintTildeOrEqual(v Version, c *constraint) bool {
 	// If there is a pre-release on the version but the constraint isn't looking
 	// for them assume that pre-releases are not compatible. See issue 21 for
 	// more details.
@@ -357,7 +357,7 @@ func constraintTildeOrEqual(v *Version, c *constraint) bool {
 // ^1.2, ^1.2.x --> >=1.2.0, <2.0.0
 // ^1.2.3 --> >=1.2.3, <2.0.0
 // ^1.2.0 --> >=1.2.0, <2.0.0
-func constraintCaret(v *Version, c *constraint) bool {
+func constraintCaret(v Version, c *constraint) bool {
 	// If there is a pre-release on the version but the constraint isn't looking
 	// for them assume that pre-releases are not compatible. See issue 21 for
 	// more details.

--- a/constraints_test.go
+++ b/constraints_test.go
@@ -98,7 +98,7 @@ func TestConstraintCheck(t *testing.T) {
 			continue
 		}
 
-		v, err := NewVersion(tc.version)
+		v, err := CoerceNewVersion(tc.version)
 		if err != nil {
 			t.Errorf("err: %s", err)
 			continue
@@ -247,7 +247,7 @@ func TestConstraintsCheck(t *testing.T) {
 			continue
 		}
 
-		v, err := NewVersion(tc.version)
+		v, err := CoerceNewVersion(tc.version)
 		if err != nil {
 			t.Errorf("err: %s", err)
 			continue
@@ -380,7 +380,7 @@ func TestConstraintsValidate(t *testing.T) {
 			continue
 		}
 
-		v, err := NewVersion(tc.version)
+		v, err := CoerceNewVersion(tc.version)
 		if err != nil {
 			t.Errorf("err: %s", err)
 			continue

--- a/version.go
+++ b/version.go
@@ -187,29 +187,26 @@ func CoerceNewVersion(v string) (Version, error) {
 		original: v,
 	}
 
-	var temp uint64
-	temp, err := strconv.ParseUint(m[1], 10, 64)
+	var err error
+	sv.major, err = strconv.ParseUint(m[1], 10, 64)
 	if err != nil {
 		return Version{}, fmt.Errorf("Error parsing version segment: %s", err)
 	}
-	sv.major = temp
 
 	if m[2] != "" {
-		temp, err = strconv.ParseUint(strings.TrimPrefix(m[2], "."), 10, 64)
+		sv.minor, err = strconv.ParseUint(strings.TrimPrefix(m[2], "."), 10, 64)
 		if err != nil {
 			return Version{}, fmt.Errorf("Error parsing version segment: %s", err)
 		}
-		sv.minor = temp
 	} else {
 		sv.minor = 0
 	}
 
 	if m[3] != "" {
-		temp, err = strconv.ParseUint(strings.TrimPrefix(m[3], "."), 10, 64)
+		sv.patch, err = strconv.ParseUint(strings.TrimPrefix(m[3], "."), 10, 64)
 		if err != nil {
 			return Version{}, fmt.Errorf("Error parsing version segment: %s", err)
 		}
-		sv.patch = temp
 	} else {
 		sv.patch = 0
 	}

--- a/version.go
+++ b/version.go
@@ -20,6 +20,17 @@ var (
 	// being parsed.
 	ErrInvalidSemVer = errors.New("Invalid Semantic Version")
 
+	// ErrEmptyString is returned when an empty string is passed in for parsing.
+	ErrEmptyString = errors.New("Version string empty")
+
+	// ErrInvalidCharacters is returned when invalid characters are found as
+	// part of a version
+	ErrInvalidCharacters = errors.New("Invalid characters in version")
+
+	// ErrSegmentStartsZero is returned when a version segment starts with 0.
+	// This is invalid in SemVer.
+	ErrSegmentStartsZero = errors.New("Version segment starts with 0")
+
 	// ErrInvalidMetadata is returned when the metadata is an invalid format
 	ErrInvalidMetadata = errors.New("Invalid Metadata string")
 
@@ -27,53 +38,166 @@ var (
 	ErrInvalidPrerelease = errors.New("Invalid Prerelease string")
 )
 
-// SemVerRegex is the regular expression used to parse a semantic version.
-const SemVerRegex string = `v?([0-9]+)(\.[0-9]+)?(\.[0-9]+)?` +
+// semVerRegex is the regular expression used to parse a semantic version.
+const semVerRegex string = `v?([0-9]+)(\.[0-9]+)?(\.[0-9]+)?` +
 	`(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
 	`(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?`
 
 // ValidPrerelease is the regular expression which validates
 // both prerelease and metadata values.
-const ValidPrerelease string = `^([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*)$`
+const validPrerelease string = `^([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*)$`
 
 // Version represents a single semantic version.
 type Version struct {
-	major, minor, patch int64
+	major, minor, patch uint64
 	pre                 string
 	metadata            string
 	original            string
 }
 
 func init() {
-	versionRegex = regexp.MustCompile("^" + SemVerRegex + "$")
-	validPrereleaseRegex = regexp.MustCompile(ValidPrerelease)
+	versionRegex = regexp.MustCompile("^" + semVerRegex + "$")
+	validPrereleaseRegex = regexp.MustCompile(validPrerelease)
 }
 
+const num string = "0123456789"
+const allowed string = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-" + num
+
 // NewVersion parses a given version and returns an instance of Version or
-// an error if unable to parse the version.
-func NewVersion(v string) (*Version, error) {
-	m := versionRegex.FindStringSubmatch(v)
-	if m == nil {
-		return nil, ErrInvalidSemVer
+// an error if unable to parse the version. Only parses valid semantic versions.
+// Performs checking that can find errors within the version.
+// If you want to coerce a version, such as 1 or 1.2, and perse that as the 1.x
+// releases of semver provided use the CoerceNewSemver() function.
+func NewVersion(v string) (Version, error) {
+	// Parsing here does not use RegEx in order to increase performance and reduce
+	// allocations.
+
+	if len(v) == 0 {
+		return Version{}, ErrEmptyString
 	}
 
-	sv := &Version{
+	// Split the parts into [0]major, [1]minor, and [2]patch,prerelease,build
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) != 3 {
+		return Version{}, ErrInvalidSemVer
+	}
+
+	sv := Version{
+		original: v,
+	}
+
+	// check for prerelease or build metadata
+	var extra []string
+	if strings.ContainsAny(parts[2], "-+") {
+		// Start with the build metadata first as it needs to be on the right
+		extra = strings.SplitN(parts[2], "+", 2)
+		if len(extra) > 1 {
+			// build metadata found
+			sv.metadata = extra[1]
+			parts[2] = extra[0]
+		}
+
+		extra = strings.SplitN(parts[2], "-", 2)
+		if len(extra) > 1 {
+			// prerelease found
+			sv.pre = extra[1]
+			parts[2] = extra[0]
+		}
+	}
+
+	// Validate the number segments are valid. This includes only having positive
+	// numbers and no leading 0's.
+	for _, p := range parts {
+		if !containsOnly(p, num) {
+			return Version{}, ErrInvalidCharacters
+		}
+
+		if len(p) > 1 && p[0] == '0' {
+			return Version{}, ErrSegmentStartsZero
+		}
+	}
+
+	// Extract the major, minor, and patch elements onto the returned Version
+	var err error
+	sv.major, err = strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return Version{}, err
+	}
+
+	sv.minor, err = strconv.ParseUint(parts[1], 10, 64)
+	if err != nil {
+		return Version{}, err
+	}
+
+	sv.patch, err = strconv.ParseUint(parts[2], 10, 64)
+	if err != nil {
+		return Version{}, err
+	}
+
+	// No prerelease or build metadata found so returning now as a fastpath.
+	if sv.pre == "" && sv.metadata == "" {
+		return sv, nil
+	}
+
+	// A prerelease was found. From the spec, "Identifiers MUST comprise only
+	// ASCII alphanumerics and hyphen [0-9A-Za-z-]. Identifiers MUST NOT be empty.
+	// Numeric identifiers MUST NOT include leading zeroes.". These segments can
+	// be dot separated.
+	if sv.pre != "" {
+		eparts := strings.Split(sv.pre, ".")
+		for _, p := range eparts {
+			if containsOnly(p, num) {
+				if len(p) > 1 && p[0] == '0' {
+					return Version{}, ErrSegmentStartsZero
+				}
+			} else if !containsOnly(p, allowed) {
+				return Version{}, ErrInvalidCharacters
+			}
+		}
+	}
+
+	// Build metadata was found. From the spec, "Build metadata MAY be denoted by
+	// appending a plus sign and a series of dot separated identifiers immediately
+	// following the patch or pre-release version. Identifiers MUST comprise only
+	// ASCII alphanumerics and hyphen [0-9A-Za-z-]. Identifiers MUST NOT be empty."
+	if sv.metadata != "" {
+		eparts := strings.Split(sv.metadata, ".")
+		for _, p := range eparts {
+			if !containsOnly(p, allowed) {
+				return Version{}, ErrInvalidCharacters
+			}
+		}
+	}
+
+	return sv, nil
+}
+
+// CoerceNewVersion parses a given version and returns an instance of Version or
+// an error if unable to parse the version. If the version is SemVer-ish it
+// attempts to convert it to SemVer.
+func CoerceNewVersion(v string) (Version, error) {
+	m := versionRegex.FindStringSubmatch(v)
+	if m == nil {
+		return Version{}, ErrInvalidSemVer
+	}
+
+	sv := Version{
 		metadata: m[8],
 		pre:      m[5],
 		original: v,
 	}
 
-	var temp int64
-	temp, err := strconv.ParseInt(m[1], 10, 64)
+	var temp uint64
+	temp, err := strconv.ParseUint(m[1], 10, 64)
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing version segment: %s", err)
+		return Version{}, fmt.Errorf("Error parsing version segment: %s", err)
 	}
 	sv.major = temp
 
 	if m[2] != "" {
-		temp, err = strconv.ParseInt(strings.TrimPrefix(m[2], "."), 10, 64)
+		temp, err = strconv.ParseUint(strings.TrimPrefix(m[2], "."), 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("Error parsing version segment: %s", err)
+			return Version{}, fmt.Errorf("Error parsing version segment: %s", err)
 		}
 		sv.minor = temp
 	} else {
@@ -81,20 +205,53 @@ func NewVersion(v string) (*Version, error) {
 	}
 
 	if m[3] != "" {
-		temp, err = strconv.ParseInt(strings.TrimPrefix(m[3], "."), 10, 64)
+		temp, err = strconv.ParseUint(strings.TrimPrefix(m[3], "."), 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("Error parsing version segment: %s", err)
+			return Version{}, fmt.Errorf("Error parsing version segment: %s", err)
 		}
 		sv.patch = temp
 	} else {
 		sv.patch = 0
 	}
 
+	// Perform some basic due diligence on the extra parts to ensure they are
+	// valid.
+
+	// A prerelease was found. From the spec, "Identifiers MUST comprise only
+	// ASCII alphanumerics and hyphen [0-9A-Za-z-]. Identifiers MUST NOT be empty.
+	// Numeric identifiers MUST NOT include leading zeroes.". These segments can
+	// be dot separated.
+	if sv.pre != "" {
+		eparts := strings.Split(sv.pre, ".")
+		for _, p := range eparts {
+			if containsOnly(p, num) {
+				if len(p) > 1 && p[0] == '0' {
+					return Version{}, ErrSegmentStartsZero
+				}
+			} else if !containsOnly(p, allowed) {
+				return Version{}, ErrInvalidCharacters
+			}
+		}
+	}
+
+	// Build metadata was found. From the spec, "Build metadata MAY be denoted by
+	// appending a plus sign and a series of dot separated identifiers immediately
+	// following the patch or pre-release version. Identifiers MUST comprise only
+	// ASCII alphanumerics and hyphen [0-9A-Za-z-]. Identifiers MUST NOT be empty."
+	if sv.metadata != "" {
+		eparts := strings.Split(sv.metadata, ".")
+		for _, p := range eparts {
+			if !containsOnly(p, allowed) {
+				return Version{}, ErrInvalidCharacters
+			}
+		}
+	}
+
 	return sv, nil
 }
 
 // MustParse parses a given version and panics on error.
-func MustParse(v string) *Version {
+func MustParse(v string) Version {
 	sv, err := NewVersion(v)
 	if err != nil {
 		panic(err)
@@ -107,7 +264,7 @@ func MustParse(v string) *Version {
 // See the Original() method to retrieve the original value. Semantic Versions
 // don't contain a leading v per the spec. Instead it's optional on
 // implementation.
-func (v *Version) String() string {
+func (v Version) String() string {
 	var buf bytes.Buffer
 
 	fmt.Fprintf(&buf, "%d.%d.%d", v.major, v.minor, v.patch)
@@ -127,32 +284,32 @@ func (v *Version) Original() string {
 }
 
 // Major returns the major version.
-func (v *Version) Major() int64 {
+func (v Version) Major() uint64 {
 	return v.major
 }
 
 // Minor returns the minor version.
-func (v *Version) Minor() int64 {
+func (v Version) Minor() uint64 {
 	return v.minor
 }
 
 // Patch returns the patch version.
-func (v *Version) Patch() int64 {
+func (v Version) Patch() uint64 {
 	return v.patch
 }
 
 // Prerelease returns the pre-release version.
-func (v *Version) Prerelease() string {
+func (v Version) Prerelease() string {
 	return v.pre
 }
 
 // Metadata returns the metadata on the version.
-func (v *Version) Metadata() string {
+func (v Version) Metadata() string {
 	return v.metadata
 }
 
 // originalVPrefix returns the original 'v' prefix if any.
-func (v *Version) originalVPrefix() string {
+func (v Version) originalVPrefix() string {
 
 	// Note, only lowercase v is supported as a prefix by the parser.
 	if v.original != "" && v.original[:1] == "v" {
@@ -217,7 +374,7 @@ func (v Version) IncMajor() Version {
 }
 
 // SetPrerelease defines the prerelease value.
-// Value must not include the required 'hypen' prefix.
+// Value must not include the required 'hyphen' prefix.
 func (v Version) SetPrerelease(prerelease string) (Version, error) {
 	vNext := v
 	if len(prerelease) > 0 && !validPrereleaseRegex.MatchString(prerelease) {
@@ -241,19 +398,19 @@ func (v Version) SetMetadata(metadata string) (Version, error) {
 }
 
 // LessThan tests if one version is less than another one.
-func (v *Version) LessThan(o *Version) bool {
+func (v *Version) LessThan(o Version) bool {
 	return v.Compare(o) < 0
 }
 
 // GreaterThan tests if one version is greater than another one.
-func (v *Version) GreaterThan(o *Version) bool {
+func (v *Version) GreaterThan(o Version) bool {
 	return v.Compare(o) > 0
 }
 
 // Equal tests if two versions are equal to each other.
 // Note, versions can be equal with different metadata since metadata
 // is not considered part of the comparable version.
-func (v *Version) Equal(o *Version) bool {
+func (v *Version) Equal(o Version) bool {
 	return v.Compare(o) == 0
 }
 
@@ -262,7 +419,7 @@ func (v *Version) Equal(o *Version) bool {
 //
 // Versions are compared by X.Y.Z. Build metadata is ignored. Prerelease is
 // lower than the version without a prerelease.
-func (v *Version) Compare(o *Version) int {
+func (v *Version) Compare(o Version) int {
 	// Compare the major, minor, and patch version for differences. If a
 	// difference is found return the comparison.
 	if d := compareSegment(v.Major(), o.Major()); d != 0 {
@@ -308,16 +465,15 @@ func (v *Version) UnmarshalJSON(b []byte) error {
 	v.pre = temp.pre
 	v.metadata = temp.metadata
 	v.original = temp.original
-	temp = nil
 	return nil
 }
 
 // MarshalJSON implements JSON.Marshaler interface.
-func (v *Version) MarshalJSON() ([]byte, error) {
+func (v Version) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.String())
 }
 
-func compareSegment(v, o int64) int {
+func compareSegment(v, o uint64) int {
 	if v < o {
 		return -1
 	}
@@ -418,4 +574,11 @@ func comparePrePart(s, o string) int {
 	}
 	return -1
 
+}
+
+// Like strings.ContainsAny but does an only instead of any.
+func containsOnly(s string, comp string) bool {
+	return strings.IndexFunc(s, func(r rune) bool {
+		return !strings.ContainsRune(comp, r)
+	}) == -1
 }

--- a/version_test.go
+++ b/version_test.go
@@ -12,6 +12,53 @@ func TestNewVersion(t *testing.T) {
 		err     bool
 	}{
 		{"1.2.3", false},
+		{"1.2.3-alpha.01", true},
+		{"1.2.3+test.01", false},
+		{"v1.2.3", true},
+		{"1.0", true},
+		{"v1.0", true},
+		{"1", true},
+		{"v1", true},
+		{"1.2.beta", true},
+		{"v1.2.beta", true},
+		{"foo", true},
+		{"1.2-5", true},
+		{"v1.2-5", true},
+		{"1.2-beta.5", true},
+		{"v1.2-beta.5", true},
+		{"\n1.2", true},
+		{"\nv1.2", true},
+		{"1.2.0-x.Y.0+metadata", false},
+		{"v1.2.0-x.Y.0+metadata", true},
+		{"1.2.0-x.Y.0+metadata-width-hypen", false},
+		{"v1.2.0-x.Y.0+metadata-width-hypen", true},
+		{"1.2.3-rc1-with-hypen", false},
+		{"v1.2.3-rc1-with-hypen", true},
+		{"1.2.3.4", true},
+		{"v1.2.3.4", true},
+		{"1.2.2147483648", false},
+		{"1.2147483648.3", false},
+		{"2147483648.3.0", false},
+	}
+
+	for _, tc := range tests {
+		_, err := NewVersion(tc.version)
+		if tc.err && err == nil {
+			t.Fatalf("expected error for version: %s", tc.version)
+		} else if !tc.err && err != nil {
+			t.Fatalf("error for version %s: %s", tc.version, err)
+		}
+	}
+}
+
+func TestCoerceNewVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		err     bool
+	}{
+		{"1.2.3", false},
+		{"1.2.3-alpha.01", true},
+		{"1.2.3+test.01", false},
 		{"v1.2.3", false},
 		{"1.0", false},
 		{"v1.0", false},
@@ -40,7 +87,7 @@ func TestNewVersion(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		_, err := NewVersion(tc.version)
+		_, err := CoerceNewVersion(tc.version)
 		if tc.err && err == nil {
 			t.Fatalf("expected error for version: %s", tc.version)
 		} else if !tc.err && err != nil {
@@ -70,20 +117,20 @@ func TestOriginal(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		v, err := NewVersion(tc)
+		v, err := CoerceNewVersion(tc)
 		if err != nil {
 			t.Errorf("Error parsing version %s", tc)
 		}
 
 		o := v.Original()
 		if o != tc {
-			t.Errorf("Error retrieving originl. Expected '%s' but got '%s'", tc, v)
+			t.Errorf("Error retrieving original. Expected '%s' but got '%v'", tc, v)
 		}
 	}
 }
 
 func TestParts(t *testing.T) {
-	v, err := NewVersion("1.2.3-beta.1+build.123")
+	v, err := CoerceNewVersion("1.2.3-beta.1+build.123")
 	if err != nil {
 		t.Error("Error parsing version 1.2.3-beta.1+build.123")
 	}
@@ -105,7 +152,7 @@ func TestParts(t *testing.T) {
 	}
 }
 
-func TestString(t *testing.T) {
+func TestCoerceString(t *testing.T) {
 	tests := []struct {
 		version  string
 		expected string
@@ -129,7 +176,7 @@ func TestString(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		v, err := NewVersion(tc.version)
+		v, err := CoerceNewVersion(tc.version)
 		if err != nil {
 			t.Errorf("Error parsing version %s", tc)
 		}
@@ -166,12 +213,12 @@ func TestCompare(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		v1, err := NewVersion(tc.v1)
+		v1, err := CoerceNewVersion(tc.v1)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}
 
-		v2, err := NewVersion(tc.v2)
+		v2, err := CoerceNewVersion(tc.v2)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}
@@ -199,12 +246,12 @@ func TestLessThan(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		v1, err := NewVersion(tc.v1)
+		v1, err := CoerceNewVersion(tc.v1)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}
 
-		v2, err := NewVersion(tc.v2)
+		v2, err := CoerceNewVersion(tc.v2)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}
@@ -237,12 +284,12 @@ func TestGreaterThan(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		v1, err := NewVersion(tc.v1)
+		v1, err := CoerceNewVersion(tc.v1)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}
 
-		v2, err := NewVersion(tc.v2)
+		v2, err := CoerceNewVersion(tc.v2)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}
@@ -271,12 +318,12 @@ func TestEqual(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		v1, err := NewVersion(tc.v1)
+		v1, err := CoerceNewVersion(tc.v1)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}
 
-		v2, err := NewVersion(tc.v2)
+		v2, err := CoerceNewVersion(tc.v2)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}
@@ -315,7 +362,7 @@ func TestInc(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		v1, err := NewVersion(tc.v1)
+		v1, err := CoerceNewVersion(tc.v1)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}
@@ -364,7 +411,7 @@ func TestSetPrerelease(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		v1, err := NewVersion(tc.v1)
+		v1, err := CoerceNewVersion(tc.v1)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}
@@ -409,7 +456,7 @@ func TestSetMetadata(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		v1, err := NewVersion(tc.v1)
+		v1, err := CoerceNewVersion(tc.v1)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}
@@ -449,7 +496,7 @@ func TestOriginalVPrefix(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		v1, _ := NewVersion(tc.version)
+		v1, _ := CoerceNewVersion(tc.version)
 		a := v1.originalVPrefix()
 		e := tc.vprefix
 		if a != e {


### PR DESCRIPTION
* NewVersion only handles spec compliant SemVer.
* NewVersion has a new method to parse the string that is faster
  than regex and uses fewer B/op. For stable versions is uses
  fewer allocs and when pre-release or metadata are on the version
  it uses 1 more alloc. All around performance is significantly
  faster
* CoerceNewVersion handles a semver-ish string. It tries to take
  a string that is similar to semver (e.g., 1.2) and turn it into
  a valid SemVer instance. This is similar to the previous handling

Closes #75