### PR TITLE
Restoring v1 Go package API

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -194,9 +194,9 @@ func benchNewVersion(v string, b *testing.B) {
 	}
 }
 
-func benchCoerceNewVersion(v string, b *testing.B) {
+func benchStrictNewVersion(v string, b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_, _ = semver.CoerceNewVersion(v)
+		_, _ = semver.StrictNewVersion(v)
 	}
 }
 
@@ -209,7 +209,7 @@ func BenchmarkNewVersionSimple(b *testing.B) {
 func BenchmarkCoerceNewVersionSimple(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
-	benchCoerceNewVersion("1.0.0", b)
+	benchStrictNewVersion("1.0.0", b)
 }
 
 func BenchmarkNewVersionPre(b *testing.B) {
@@ -218,10 +218,10 @@ func BenchmarkNewVersionPre(b *testing.B) {
 	benchNewVersion("1.0.0-alpha", b)
 }
 
-func BenchmarkCoerceNewVersionPre(b *testing.B) {
+func BenchmarkStrictNewVersionPre(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
-	benchCoerceNewVersion("1.0.0-alpha", b)
+	benchStrictNewVersion("1.0.0-alpha", b)
 }
 
 func BenchmarkNewVersionMeta(b *testing.B) {
@@ -230,10 +230,10 @@ func BenchmarkNewVersionMeta(b *testing.B) {
 	benchNewVersion("1.0.0+metadata", b)
 }
 
-func BenchmarkCoerceNewVersionMeta(b *testing.B) {
+func BenchmarkStrictNewVersionMeta(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
-	benchCoerceNewVersion("1.0.0+metadata", b)
+	benchStrictNewVersion("1.0.0+metadata", b)
 }
 
 func BenchmarkNewVersionMetaDash(b *testing.B) {
@@ -242,8 +242,8 @@ func BenchmarkNewVersionMetaDash(b *testing.B) {
 	benchNewVersion("1.0.0-alpha.1+meta.data", b)
 }
 
-func BenchmarkCoerceNewVersionMetaDash(b *testing.B) {
+func BenchmarkStrictNewVersionMetaDash(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
-	benchCoerceNewVersion("1.0.0-alpha.1+meta.data", b)
+	benchStrictNewVersion("1.0.0-alpha.1+meta.data", b)
 }

--- a/collection.go
+++ b/collection.go
@@ -3,7 +3,7 @@ package semver
 // Collection is a collection of Version instances and implements the sort
 // interface. See the sort package for more details.
 // https://golang.org/pkg/sort/
-type Collection []Version
+type Collection []*Version
 
 // Len returns the length of a collection. The number of Version instances
 // on the slice.

--- a/collection_test.go
+++ b/collection_test.go
@@ -15,9 +15,9 @@ func TestCollection(t *testing.T) {
 		"0.4.2",
 	}
 
-	vs := make([]Version, len(raw))
+	vs := make([]*Version, len(raw))
 	for i, r := range raw {
-		v, err := CoerceNewVersion(r)
+		v, err := NewVersion(r)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}

--- a/constraints_test.go
+++ b/constraints_test.go
@@ -142,7 +142,7 @@ func TestConstraintCheck(t *testing.T) {
 			continue
 		}
 
-		v, err := CoerceNewVersion(tc.version)
+		v, err := NewVersion(tc.version)
 		if err != nil {
 			t.Errorf("err: %s", err)
 			continue
@@ -296,7 +296,7 @@ func TestConstraintsCheck(t *testing.T) {
 			continue
 		}
 
-		v, err := CoerceNewVersion(tc.version)
+		v, err := NewVersion(tc.version)
 		if err != nil {
 			t.Errorf("err: %s", err)
 			continue
@@ -432,7 +432,7 @@ func TestConstraintsValidate(t *testing.T) {
 			continue
 		}
 
-		v, err := CoerceNewVersion(tc.version)
+		v, err := NewVersion(tc.version)
 		if err != nil {
 			t.Errorf("err: %s", err)
 			continue
@@ -452,7 +452,7 @@ func TestConstraintsValidate(t *testing.T) {
 		// }
 	}
 
-	v, err := NewVersion("1.2.3")
+	v, err := StrictNewVersion("1.2.3")
 	if err != nil {
 		t.Errorf("err: %s", err)
 	}
@@ -517,7 +517,7 @@ func TestConstraintsValidate(t *testing.T) {
 			continue
 		}
 
-		v, err := NewVersion(tc.version)
+		v, err := StrictNewVersion(tc.version)
 		if err != nil {
 			t.Errorf("err: %s", err)
 			continue

--- a/version_test.go
+++ b/version_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestNewVersion(t *testing.T) {
+func TestStrictNewVersion(t *testing.T) {
 	tests := []struct {
 		version string
 		err     bool
@@ -43,7 +43,7 @@ func TestNewVersion(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		_, err := NewVersion(tc.version)
+		_, err := StrictNewVersion(tc.version)
 		if tc.err && err == nil {
 			t.Fatalf("expected error for version: %s", tc.version)
 		} else if !tc.err && err != nil {
@@ -52,7 +52,7 @@ func TestNewVersion(t *testing.T) {
 	}
 }
 
-func TestCoerceNewVersion(t *testing.T) {
+func TestNewVersion(t *testing.T) {
 	tests := []struct {
 		version string
 		err     bool
@@ -89,7 +89,7 @@ func TestCoerceNewVersion(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		_, err := CoerceNewVersion(tc.version)
+		_, err := NewVersion(tc.version)
 		if tc.err && err == nil {
 			t.Fatalf("expected error for version: %s", tc.version)
 		} else if !tc.err && err != nil {
@@ -119,7 +119,7 @@ func TestOriginal(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		v, err := CoerceNewVersion(tc)
+		v, err := NewVersion(tc)
 		if err != nil {
 			t.Errorf("Error parsing version %s", tc)
 		}
@@ -132,7 +132,7 @@ func TestOriginal(t *testing.T) {
 }
 
 func TestParts(t *testing.T) {
-	v, err := CoerceNewVersion("1.2.3-beta.1+build.123")
+	v, err := NewVersion("1.2.3-beta.1+build.123")
 	if err != nil {
 		t.Error("Error parsing version 1.2.3-beta.1+build.123")
 	}
@@ -178,7 +178,7 @@ func TestCoerceString(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		v, err := CoerceNewVersion(tc.version)
+		v, err := NewVersion(tc.version)
 		if err != nil {
 			t.Errorf("Error parsing version %s", tc)
 		}
@@ -218,12 +218,12 @@ func TestCompare(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		v1, err := CoerceNewVersion(tc.v1)
+		v1, err := NewVersion(tc.v1)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}
 
-		v2, err := CoerceNewVersion(tc.v2)
+		v2, err := NewVersion(tc.v2)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}
@@ -251,12 +251,12 @@ func TestLessThan(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		v1, err := CoerceNewVersion(tc.v1)
+		v1, err := NewVersion(tc.v1)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}
 
-		v2, err := CoerceNewVersion(tc.v2)
+		v2, err := NewVersion(tc.v2)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}
@@ -289,12 +289,12 @@ func TestGreaterThan(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		v1, err := CoerceNewVersion(tc.v1)
+		v1, err := NewVersion(tc.v1)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}
 
-		v2, err := CoerceNewVersion(tc.v2)
+		v2, err := NewVersion(tc.v2)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}
@@ -323,12 +323,12 @@ func TestEqual(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		v1, err := CoerceNewVersion(tc.v1)
+		v1, err := NewVersion(tc.v1)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}
 
-		v2, err := CoerceNewVersion(tc.v2)
+		v2, err := NewVersion(tc.v2)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}
@@ -367,7 +367,7 @@ func TestInc(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		v1, err := CoerceNewVersion(tc.v1)
+		v1, err := NewVersion(tc.v1)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}
@@ -416,7 +416,7 @@ func TestSetPrerelease(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		v1, err := CoerceNewVersion(tc.v1)
+		v1, err := NewVersion(tc.v1)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}
@@ -461,7 +461,7 @@ func TestSetMetadata(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		v1, err := CoerceNewVersion(tc.v1)
+		v1, err := NewVersion(tc.v1)
 		if err != nil {
 			t.Errorf("Error parsing version: %s", err)
 		}
@@ -501,7 +501,7 @@ func TestOriginalVPrefix(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		v1, _ := CoerceNewVersion(tc.version)
+		v1, _ := NewVersion(tc.version)
 		a := v1.originalVPrefix()
 		e := tc.vprefix
 		if a != e {
@@ -512,7 +512,7 @@ func TestOriginalVPrefix(t *testing.T) {
 
 func TestJsonMarshal(t *testing.T) {
 	sVer := "1.1.1"
-	x, err := NewVersion(sVer)
+	x, err := StrictNewVersion(sVer)
 	if err != nil {
 		t.Errorf("Error creating version: %s", err)
 	}


### PR DESCRIPTION
There have been issues reported by those installing applications
using go get where semver no longer works because the API changed.
This commit restores the Go API to the old interface.

Note, some of the performance improvement (including allocations
and speed) were lost in this change.

Some functions were renamed including:
* CoerceNewVersion -> NewVersion
* NewVersion -> StrictNewVersion