### PR TITLE
Fixing prerelease comparisons

### DIFF
--- a/version.go
+++ b/version.go
@@ -403,25 +403,49 @@ func comparePrePart(s, o string) int {
 
 	// When s or o are empty we can use the other in an attempt to determine
 	// the response.
-	if o == "" {
-		_, n := strconv.ParseUint(s, 10, 64)
-		if n != nil {
+	if s == "" {
+		if o != "" {
 			return -1
 		}
 		return 1
 	}
-	if s == "" {
-		_, n := strconv.ParseUint(o, 10, 64)
-		if n != nil {
+
+	if o == "" {
+		if s != "" {
 			return 1
 		}
 		return -1
 	}
 
-	if s > o {
+	// When comparing strings "99" is greater than "103". To handle
+	// cases like this we need to detect numbers and compare them. According
+	// to the semver spec, numbers are always positive. If there is a - at the
+	// start like -99 this is to be evaluated as an alphanum. numbers always
+	// have precedence over alphanum. Parsing as Uints because negative numbers
+	// are ignored.
+
+	oi, n1 := strconv.ParseUint(o, 10, 64)
+	si, n2 := strconv.ParseUint(s, 10, 64)
+
+	// The case where both are strings compare the strings
+	if n1 != nil && n2 != nil {
+		if s > o {
+			return 1
+		}
+		return -1
+	} else if n1 != nil {
+		// o is a string and s is a number
+		return -1
+	} else if n2 != nil {
+		// s is a string and o is a number
+		return 1
+	}
+	// Both are numbers
+	if si > oi {
 		return 1
 	}
 	return -1
+
 }
 
 func numPartsEq(v1, v2 Version) bool {

--- a/version_test.go
+++ b/version_test.go
@@ -154,9 +154,10 @@ func TestCompare(t *testing.T) {
 		{"4.2-beta.2", "4.2-beta.1", 1},
 		{"4.2-beta2", "4.2-beta1", 1},
 		{"4.2-beta", "4.2-beta.2", -1},
-		{"4.2-beta", "4.2-beta.foo", 1},
+		{"4.2-beta", "4.2-beta.foo", -1},
+		{"4.2-alpha", "4.2-beta.2", -1},
 		{"4.2-beta.2", "4.2-beta", 1},
-		{"4.2-beta.foo", "4.2-beta", -1},
+		{"4.2-beta.foo", "4.2-beta", 1},
 		{"1.2+bar", "1.2+baz", 0},
 	}
 


### PR DESCRIPTION
This copies the fixed function used on the `release-1` and `mater` branches.