### PR TITLE
Add support for SQL

### DIFF
--- a/version.go
+++ b/version.go
@@ -2,6 +2,7 @@ package semver
 
 import (
 	"bytes"
+	"database/sql/driver"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -433,6 +434,28 @@ func (v *Version) UnmarshalJSON(b []byte) error {
 // MarshalJSON implements JSON.Marshaler interface.
 func (v Version) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.String())
+}
+
+// Scan implements the SQL.Scanner interface.
+func (v *Version) Scan(value interface{}) error {
+	var s string
+	s, _ = value.(string)
+	temp, err := NewVersion(s)
+	if err != nil {
+		return err
+	}
+	v.major = temp.major
+	v.minor = temp.minor
+	v.patch = temp.patch
+	v.pre = temp.pre
+	v.metadata = temp.metadata
+	v.original = temp.original
+	return nil
+}
+
+// Value implements the Driver.Valuer interface.
+func (v Version) Value() (driver.Value, error) {
+	return v.String(), nil
 }
 
 func compareSegment(v, o uint64) int {

--- a/version_test.go
+++ b/version_test.go
@@ -1,6 +1,7 @@
 package semver
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -538,6 +539,41 @@ func TestJsonUnmarshal(t *testing.T) {
 	want := sVer
 	if got != want {
 		t.Errorf("Error unmarshaling unexpected object content: got=%q want=%q", got, want)
+	}
+}
+
+func TestSQLScanner(t *testing.T) {
+	sVer := "1.1.1"
+	x, err := StrictNewVersion(sVer)
+	if err != nil {
+		t.Errorf("Error creating version: %s", err)
+	}
+	var s sql.Scanner = x
+	var out *Version
+	var ok bool
+	if out, ok = s.(*Version); !ok {
+		t.Errorf("Error expected Version type, got=%T want=%T", s, Version{})
+	}
+	got := out.String()
+	want := sVer
+	if got != want {
+		t.Errorf("Error sql scanner unexpected scan content: got=%q want=%q", got, want)
+	}
+}
+
+func TestDriverValuer(t *testing.T) {
+	sVer := "1.1.1"
+	x, err := StrictNewVersion(sVer)
+	if err != nil {
+		t.Errorf("Error creating version: %s", err)
+	}
+	got, err := x.Value()
+	if err != nil {
+		t.Fatalf("Error getting value, got %v", err)
+	}
+	want := sVer
+	if got != want {
+		t.Errorf("Error driver valuer unexpected value content: got=%q want=%q", got, want)
 	}
 }
 


### PR DESCRIPTION
implement the `driver.Valuer` and `sql.Scanner` interfaces to support using `Version` type as a database field

- `sql.Scanner`: https://golang.org/pkg/database/sql/#Scanner
- `driver.Valuer`: https://golang.org/pkg/database/sql/driver/#Valuer