### PR TITLE
[Don't merge] Add tests for demonstrative purpose

### DIFF
--- a/constraints_test.go
+++ b/constraints_test.go
@@ -183,6 +183,17 @@ func TestConstraintCheck(t *testing.T) {
 		{"^0.2.3-beta.2", "0.2.4-beta.2", true},
 		{"^0.2.3-beta.2", "0.3.4-beta.2", false},
 		{"^0.2.3-beta.2", "0.2.3-beta.2", true},
+
+		// For discussion and demonstration purposes currently
+		// These tests are valid, and make sense to me.
+		{"1.0.0", "1.0.0+002.sdgf234", true},
+		{"1.0.0-beta.1", "1.0.0-beta.1+002.sdgf234", true},
+		
+		// Test will fail below, a constraint created from 1.0.0+001.asdf123
+		// accepts a version with a different build argument, shoult it?
+		// I note that the npm semver package also considers this fine.
+		{"1.0.0+001.asdf123", "1.0.0+002.sdgf234", false},
+		{"1.0.0-beta.1+001.asdf123", "1.0.0-beta.1+002.sdgf234", false},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
I wanted to demo something I discuss in #137, that based on logic implemented in the Helm client CLI leads to https://github.com/helm/helm/issues/6710.

A constraint created from a version like `1.0.0+001.foo` is consider satisfied or `Check()` against the version `1.0.0+009.bar`. Should it?