### PR TITLE
Forcing ordered operation when generating regex

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.12.x, 1.13.x, 1.14.x]
+        go-version: [1.12.x, 1.13.x, 1.14.x, 1.15.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/constraints.go
+++ b/constraints.go
@@ -164,14 +164,11 @@ func init() {
 		"^":  constraintCaret,
 	}
 
-	ops := make([]string, 0, len(constraintOps))
-	for k := range constraintOps {
-		ops = append(ops, regexp.QuoteMeta(k))
-	}
+	ops := `=||!=|>|<|>=|=>|<=|=<|~|~>|\^`
 
 	constraintRegex = regexp.MustCompile(fmt.Sprintf(
 		`^\s*(%s)\s*(%s)\s*$`,
-		strings.Join(ops, "|"),
+		ops,
 		cvRegex))
 
 	constraintRangeRegex = regexp.MustCompile(fmt.Sprintf(
@@ -180,12 +177,12 @@ func init() {
 
 	findConstraintRegex = regexp.MustCompile(fmt.Sprintf(
 		`(%s)\s*(%s)`,
-		strings.Join(ops, "|"),
+		ops,
 		cvRegex))
 
 	validConstraintRegex = regexp.MustCompile(fmt.Sprintf(
 		`^(\s*(%s)\s*(%s)\s*\,?)+$`,
-		strings.Join(ops, "|"),
+		ops,
 		cvRegex))
 }
 


### PR DESCRIPTION
Range was used to iterate over the operations as part of generating
the regex. Range iterations are random. There were cases where the
empty key caused the regex to be generated as invalid.

This change removes the range so that the order is always the same.

Closes #155