### PR TITLE
gofumpt on repo

### DIFF
--- a/constraints.go
+++ b/constraints.go
@@ -17,7 +17,6 @@ type Constraints struct {
 // NewConstraint returns a Constraints instance that a Version instance can
 // be checked against. If there is a parse error it will be returned.
 func NewConstraint(c string) (*Constraints, error) {
-
 	// Rewrite - ranges into a comparison operation.
 	c = rewriteRange(c)
 
@@ -97,7 +96,6 @@ func (cs Constraints) Validate(v *Version) (bool, []error) {
 				joy = false
 
 			} else {
-
 				if _, err := c.check(v); err != nil {
 					e = append(e, err)
 					joy = false
@@ -134,9 +132,11 @@ func (cs Constraints) String() string {
 	return strings.Join(buf, " || ")
 }
 
-var constraintOps map[string]cfunc
-var constraintRegex *regexp.Regexp
-var constraintRangeRegex *regexp.Regexp
+var (
+	constraintOps        map[string]cfunc
+	constraintRegex      *regexp.Regexp
+	constraintRangeRegex *regexp.Regexp
+)
 
 // Used to find individual constraints within a multi-constraint string
 var findConstraintRegex *regexp.Regexp
@@ -247,7 +247,6 @@ func parseConstraint(c string) (*constraint, error) {
 
 		con, err := NewVersion(ver)
 		if err != nil {
-
 			// The constraintRegex should catch any regex parsing errors. So,
 			// we should never get here.
 			return nil, errors.New("constraint Parser Error")
@@ -265,7 +264,6 @@ func parseConstraint(c string) (*constraint, error) {
 	// is equivalent to * or >=0.0.0
 	con, err := StrictNewVersion("0.0.0")
 	if err != nil {
-
 		// The constraintRegex should catch any regex parsing errors. So,
 		// we should never get here.
 		return nil, errors.New("constraint Parser Error")
@@ -324,7 +322,6 @@ func constraintNotEqual(v *Version, c *constraint) (bool, error) {
 }
 
 func constraintGreaterThan(v *Version, c *constraint) (bool, error) {
-
 	// If there is a pre-release on the version but the constraint isn't looking
 	// for them assume that pre-releases are not compatible. See issue 21 for
 	// more details.
@@ -385,7 +382,6 @@ func constraintLessThan(v *Version, c *constraint) (bool, error) {
 }
 
 func constraintGreaterThanEqual(v *Version, c *constraint) (bool, error) {
-
 	// If there is a pre-release on the version but the constraint isn't looking
 	// for them assume that pre-releases are not compatible. See issue 21 for
 	// more details.

--- a/fuzz.go
+++ b/fuzz.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package semver

--- a/version.go
+++ b/version.go
@@ -55,8 +55,10 @@ func init() {
 	versionRegex = regexp.MustCompile("^" + semVerRegex + "$")
 }
 
-const num string = "0123456789"
-const allowed string = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-" + num
+const (
+	num     string = "0123456789"
+	allowed string = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-" + num
+)
 
 // StrictNewVersion parses a given version and returns an instance of Version or
 // an error if unable to parse the version. Only parses valid semantic versions.
@@ -267,7 +269,6 @@ func (v Version) Metadata() string {
 
 // originalVPrefix returns the original 'v' prefix if any.
 func (v Version) originalVPrefix() string {
-
 	// Note, only lowercase v is supported as a prefix by the parser.
 	if v.original != "" && v.original[:1] == "v" {
 		return v.original[:1]
@@ -470,7 +471,6 @@ func compareSegment(v, o uint64) int {
 }
 
 func comparePrerelease(v, o string) int {
-
 	// split the prelease versions by their part. The separator, per the spec,
 	// is a .
 	sparts := strings.Split(v, ".")
@@ -562,11 +562,10 @@ func comparePrePart(s, o string) int {
 		return 1
 	}
 	return -1
-
 }
 
 // Like strings.ContainsAny but does an only instead of any.
-func containsOnly(s string, comp string) bool {
+func containsOnly(s, comp string) bool {
 	return strings.IndexFunc(s, func(r rune) bool {
 		return !strings.ContainsRune(comp, r)
 	}) == -1


### PR DESCRIPTION
This PR is simply [gofumpt](https://github.com/mvdan/gofumpt) run on the codebase.