### PR TITLE
Add minor version check for caret (^) when minor version in constraint is 0(zero)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,23 +4,27 @@ run:
 linters:
   disable-all: true
   enable:
-    - deadcode
-    - dupl
-    - errcheck
-    - gofmt
-    - goimports
-    - golint
-    - gosimple
-    - govet
-    - ineffassign
     - misspell
-    - nakedret
     - structcheck
-    - unused
+    - govet
+    - staticcheck
+    - deadcode
+    - errcheck
     - varcheck
+    - unparam
+    - ineffassign
+    - nakedret
+    - gocyclo
+    - dupl
+    - goimports
+    - revive
+    - gosec
+    - gosimple
+    - typecheck
+    - unused
 
 linters-settings:
   gofmt:
     simplify: true
   dupl:
-    threshold: 400
+    threshold: 600

--- a/constraints.go
+++ b/constraints.go
@@ -534,6 +534,10 @@ func constraintCaret(v *Version, c *constraint) (bool, error) {
 		}
 		return false, fmt.Errorf("%s does not have same minor version as %s. Expected minor versions to match when constraint major version is 0", v, c.orig)
 	}
+	// ^ when the minor is 0 and minor > 0 is >=0.y.z < 0.y+1
+	if c.con.Minor() == 0 && v.Minor() > 0 {
+		return false, fmt.Errorf("%s does not have same minor version as %s", v, c.orig)
+	}
 
 	// At this point the major is 0 and the minor is 0 and not dirty. The patch
 	// is not dirty so we need to check if they are equal. If they are not equal

--- a/constraints.go
+++ b/constraints.go
@@ -534,7 +534,7 @@ func constraintCaret(v *Version, c *constraint) (bool, error) {
 		}
 		return false, fmt.Errorf("%s does not have same minor version as %s. Expected minor versions to match when constraint major version is 0", v, c.orig)
 	}
-	// ^ when the minor is 0 and minor > 0 is >=0.y.z < 0.y+1
+	// ^ when the minor is 0 and minor > 0 is =0.0.z
 	if c.con.Minor() == 0 && v.Minor() > 0 {
 		return false, fmt.Errorf("%s does not have same minor version as %s", v, c.orig)
 	}

--- a/constraints_test.go
+++ b/constraints_test.go
@@ -600,7 +600,7 @@ func TestConstraintsValidate(t *testing.T) {
 		{"^1.x", "2.1.1", "2.1.1 does not have same major version as 1.x"},
 		{"^0.2", "0.3.0", "0.3.0 does not have same minor version as 0.2. Expected minor versions to match when constraint major version is 0"},
 		{"^0.2", "0.1.1", "0.1.1 is less than 0.2"},
-		{"^0.0.3", "0.1.1", "0.1.1 does not equal 0.0.3. Expect version and constraint to equal when major and minor versions are 0"},
+		{"^0.0.3", "0.1.1", "0.1.1 does not have same minor version as 0.0.3"},
 		{"^0.0.3", "0.0.4", "0.0.4 does not equal 0.0.3. Expect version and constraint to equal when major and minor versions are 0"},
 		{"^0.0.3", "0.0.2", "0.0.2 is less than 0.0.3"},
 		{"~1", "2.1.2", "2.1.2 does not have same major version as 1"},

--- a/constraints_test.go
+++ b/constraints_test.go
@@ -362,6 +362,8 @@ func TestConstraintsCheck(t *testing.T) {
 		{"^1.x", "1.1.1-beta1", false},
 		{"^1.1.2-alpha", "1.2.1-beta1", true},
 		{"^1.2.x-alpha", "1.1.1-beta1", false},
+		{"^0.0.1", "0.0.1", true},
+		{"^0.0.1", "0.3.1", false},
 		{"~*", "2.1.1", true},
 		{"~1", "2.1.1", false},
 		{"~1", "1.3.5", true},


### PR DESCRIPTION
This PR aims to fix https://github.com/Masterminds/semver/issues/180
 
Please take a look when you can 😄 