### PR TITLE
Fixing issue where validation of constraint section gave false positives

### DIFF
--- a/constraints.go
+++ b/constraints.go
@@ -180,8 +180,13 @@ func init() {
 		ops,
 		cvRegex))
 
+	// The first time a constraint shows up will look slightly different from
+	// future times it shows up due to a leading space or comma in a given
+	// string.
 	validConstraintRegex = regexp.MustCompile(fmt.Sprintf(
-		`^(\s*(%s)\s*(%s)\s*\,?)+$`,
+		`^(\s*(%s)\s*(%s)\s*)((?:\s+|,\s*)(%s)\s*(%s)\s*)*$`,
+		ops,
+		cvRegex,
 		ops,
 		cvRegex))
 }

--- a/constraints_test.go
+++ b/constraints_test.go
@@ -231,6 +231,15 @@ func TestNewConstraint(t *testing.T) {
 
 		// The 3 - 4 should be broken into 2 by the range rewriting
 		{"3 - 4 || => 3.0, < 4", 2, 2, false},
+
+		// Due to having 4 parts these should produce an error. See
+		// https://github.com/Masterminds/semver/issues/185 for the reason for
+		// these tests.
+		{"12.3.4.1234", 0, 0, true},
+		{"12.23.4.1234", 0, 0, true},
+		{"12.3.34.1234", 0, 0, true},
+		{"12.3.34 ~1.2.3", 1, 2, false},
+		{"12.3.34~ 1.2.3", 0, 0, true},
 	}
 
 	for _, tc := range tests {

--- a/version_test.go
+++ b/version_test.go
@@ -87,6 +87,13 @@ func TestNewVersion(t *testing.T) {
 		{"1.2.2147483648", false},
 		{"1.2147483648.3", false},
 		{"2147483648.3.0", false},
+
+		// Due to having 4 parts these should produce an error. See
+		// https://github.com/Masterminds/semver/issues/185 for the reason for
+		// these tests.
+		{"12.3.4.1234", true},
+		{"12.23.4.1234", true},
+		{"12.3.34.1234", true},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Closes #185

Validation of strings was producing false positives when there were too
many sections. A string like 1.2.3.1234 would be found in error but on
like 1.23.3.1234 or 1.2.34.1234 could pass even though it had too many
segments. This is because a string like 1.23.3.1234 would be found as
two different constraints of 1.1 and 3.3.1234.

The fix was to treat validation for the the first and following
constraints separately. For for the following ones a space or command
is now required before it to show it's a second or further one.