### PR TITLE
Add GreaterThanOrEqual and LessThanOrEqual methods

### DIFF
--- a/version.go
+++ b/version.go
@@ -381,9 +381,19 @@ func (v *Version) LessThan(o *Version) bool {
 	return v.Compare(o) < 0
 }
 
+// LessThanOrEqual tests if one version is less than or equal to another one.
+func (v *Version) LessThanOrEqual(o *Version) bool {
+	return v.Compare(o) <= 0
+}
+
 // GreaterThan tests if one version is greater than another one.
 func (v *Version) GreaterThan(o *Version) bool {
 	return v.Compare(o) > 0
+}
+
+// GreaterThanOrEqual tests if one version is greater than or equal to another one.
+func (v *Version) GreaterThanOrEqual(o *Version) bool {
+	return v.Compare(o) >= 0
 }
 
 // Equal tests if two versions are equal to each other.

--- a/version_test.go
+++ b/version_test.go
@@ -296,6 +296,39 @@ func TestLessThan(t *testing.T) {
 	}
 }
 
+func TestLessThanOrEqual(t *testing.T) {
+	tests := []struct {
+		v1       string
+		v2       string
+		expected bool
+	}{
+		{"1.2.3", "1.5.1", true},
+		{"2.2.3", "1.5.1", false},
+		{"3.2-beta", "3.2-beta", true},
+	}
+
+	for _, tc := range tests {
+		v1, err := NewVersion(tc.v1)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		v2, err := NewVersion(tc.v2)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		a := v1.LessThanOrEqual(v2)
+		e := tc.expected
+		if a != e {
+			t.Errorf(
+				"Comparison of '%s' and '%s' failed. Expected '%t', got '%t'",
+				tc.v1, tc.v2, e, a,
+			)
+		}
+	}
+}
+
 func TestGreaterThan(t *testing.T) {
 	tests := []struct {
 		v1       string
@@ -324,6 +357,44 @@ func TestGreaterThan(t *testing.T) {
 		}
 
 		a := v1.GreaterThan(v2)
+		e := tc.expected
+		if a != e {
+			t.Errorf(
+				"Comparison of '%s' and '%s' failed. Expected '%t', got '%t'",
+				tc.v1, tc.v2, e, a,
+			)
+		}
+	}
+}
+
+func TestGreaterThanOrEqual(t *testing.T) {
+	tests := []struct {
+		v1       string
+		v2       string
+		expected bool
+	}{
+		{"1.2.3", "1.5.1", false},
+		{"2.2.3", "1.5.1", true},
+		{"3.2-beta", "3.2-beta", true},
+		{"3.2.0-beta.1", "3.2.0-beta.5", false},
+		{"3.2-beta.4", "3.2-beta.2", true},
+		{"7.43.0-SNAPSHOT.99", "7.43.0-SNAPSHOT.103", false},
+		{"7.43.0-SNAPSHOT.FOO", "7.43.0-SNAPSHOT.103", true},
+		{"7.43.0-SNAPSHOT.99", "7.43.0-SNAPSHOT.BAR", false},
+	}
+
+	for _, tc := range tests {
+		v1, err := NewVersion(tc.v1)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		v2, err := NewVersion(tc.v2)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		a := v1.GreaterThanOrEqual(v2)
 		e := tc.expected
 		if a != e {
 			t.Errorf(


### PR DESCRIPTION
Simple PR to add `LessThanOrEqual` and `GreaterThanOrEqual` methods. These are syntactically the same as the existing `LessThan`, `GreaterThan` and `Equal` methods in that they are just wrappers around `Compare`.

The main motivation for this is code readability. I have several places in my projects where I am doing something like this: 

```go
const v3 = semver.MustParse("3")
...
if version.Compare(v3) >= 0 {
    // do something
}
```

it would be much more readable to use these new wrappers:

```go
const v3 = semver.MustParse("3")
...
if version.GreaterThanOrEqual(v3) {
    // do something
}
```