### PR TITLE
when sorting break ties with lexical comparison

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -14,7 +14,11 @@ func (c Collection) Len() int {
 // Less is needed for the sort interface to compare two Version objects on the
 // slice. If checks if one is less than the other.
 func (c Collection) Less(i, j int) bool {
-	return c[i].LessThan(c[j])
+	comp := c[i].Compare(c[j])
+	if comp != 0 {
+		return comp < 0
+	}
+	return c[i].Original() < c[j].Original()
 }
 
 // Swap is needed for the sort interface to replace the Version objects


### PR DESCRIPTION
The manner in which comparisons are evaluated is correct. This PR doesn't seek to change that. `1.24` _is_ equivalent to `1.24.0`, _however_, when sorting lists that contain both these values, those two may appear in either order in relation to one another.

This PR breaks ties (only when sorting) through a lexical comparison of the original strings.