### PR TITLE
fix: typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### Added
 
-- #190: Added text marshaling and unmarshaling
+- #190: Added text marshaling and unmarshalling
 - #167: Added JSON marshalling for constraints (thanks @SimonTheLeg)
 - #173: Implement encoding.TextMarshaler and encoding.TextUnmarshaler on Version (thanks @MarkRosemaker)
 - #179: Added New() version constructor (thanks @kazhuravlev)
@@ -130,7 +130,7 @@ functions. These are described in the added and changed sections below.
 
 ### Changed
 
-- #72: Updated the docs to point to vert for a console appliaction
+- #72: Updated the docs to point to vert for a console application
 - #71: Update the docs on pre-release comparator handling
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you are looking for a command line tool for version comparisons please see
 
 Note, import `github.com/github.com/Masterminds/semver/v3` to use the latest version.
 
-There are three major versions fo the `semver` package.
+There are three major versions of the `semver` package.
 
 * 3.x.x is the stable and active version. This version is focused on constraint
   compatibility for range handling in other tools from other languages. It has

--- a/constraints_test.go
+++ b/constraints_test.go
@@ -683,7 +683,7 @@ func TestConstraintString(t *testing.T) {
 		}
 
 		if _, err = NewConstraint(c.String()); err != nil {
-			t.Errorf("expected string from constrint %q to parse as valid but got err: %s", tc.constraint, err)
+			t.Errorf("expected string from constraint %q to parse as valid but got err: %s", tc.constraint, err)
 		}
 	}
 }
@@ -728,7 +728,7 @@ func TestTextMarshalConstraints(t *testing.T) {
 		enc.SetEscapeHTML(false)
 		err = enc.Encode(cs)
 		if err != nil {
-			t.Errorf("Error unmarshaling constraint: %s", err)
+			t.Errorf("Error unmarshalling constraint: %s", err)
 		}
 		got = buf.String()
 		// The encoder used here adds a newline so we add that to what we want
@@ -757,22 +757,22 @@ func TestTextUnmarshalConstraints(t *testing.T) {
 		cs := Constraints{}
 		err := cs.UnmarshalText([]byte(tc.constraint))
 		if err != nil {
-			t.Errorf("Error unmarshaling constraints: %s", err)
+			t.Errorf("Error unmarshalling constraints: %s", err)
 		}
 		got := cs.String()
 		if got != tc.want {
-			t.Errorf("Error unmarshaling constraint, unexpected object content: got=%q want=%q", got, tc.want)
+			t.Errorf("Error unmarshalling constraint, unexpected object content: got=%q want=%q", got, tc.want)
 		}
 
-		// Test that this works for JSON as well as text. When JSON unmarshaling
+		// Test that this works for JSON as well as text. When JSON unmarshalling
 		// functions are missing it falls through to TextUnmarshal.
 		err = json.Unmarshal([]byte(fmt.Sprintf("%q", tc.constraint)), &cs)
 		if err != nil {
-			t.Errorf("Error unmarshaling constraints: %s", err)
+			t.Errorf("Error unmarshalling constraints: %s", err)
 		}
 		got = cs.String()
 		if got != tc.want {
-			t.Errorf("Error unmarshaling constraint, unexpected object content: got=%q want=%q", got, tc.want)
+			t.Errorf("Error unmarshalling constraint, unexpected object content: got=%q want=%q", got, tc.want)
 		}
 	}
 }

--- a/version.go
+++ b/version.go
@@ -522,7 +522,7 @@ func comparePrerelease(v, o string) int {
 
 	// Iterate over each part of the prereleases to compare the differences.
 	for i := 0; i < l; i++ {
-		// Since the lentgh of the parts can be different we need to create
+		// Since the length of the parts can be different we need to create
 		// a placeholder. This is to avoid out of bounds issues.
 		stemp := ""
 		if i < slen {

--- a/version_test.go
+++ b/version_test.go
@@ -32,10 +32,10 @@ func TestStrictNewVersion(t *testing.T) {
 		{"\nv1.2", true},
 		{"1.2.0-x.Y.0+metadata", false},
 		{"v1.2.0-x.Y.0+metadata", true},
-		{"1.2.0-x.Y.0+metadata-width-hypen", false},
-		{"v1.2.0-x.Y.0+metadata-width-hypen", true},
-		{"1.2.3-rc1-with-hypen", false},
-		{"v1.2.3-rc1-with-hypen", true},
+		{"1.2.0-x.Y.0+metadata-width-hyphen", false},
+		{"v1.2.0-x.Y.0+metadata-width-hyphen", true},
+		{"1.2.3-rc1-with-hyphen", false},
+		{"v1.2.3-rc1-with-hyphen", true},
 		{"1.2.3.4", true},
 		{"v1.2.3.4", true},
 		{"1.2.2147483648", false},
@@ -82,10 +82,10 @@ func TestNewVersion(t *testing.T) {
 		{"\nv1.2", true},
 		{"1.2.0-x.Y.0+metadata", false},
 		{"v1.2.0-x.Y.0+metadata", false},
-		{"1.2.0-x.Y.0+metadata-width-hypen", false},
-		{"v1.2.0-x.Y.0+metadata-width-hypen", false},
-		{"1.2.3-rc1-with-hypen", false},
-		{"v1.2.3-rc1-with-hypen", false},
+		{"1.2.0-x.Y.0+metadata-width-hyphen", false},
+		{"v1.2.0-x.Y.0+metadata-width-hyphen", false},
+		{"1.2.3-rc1-with-hyphen", false},
+		{"v1.2.3-rc1-with-hyphen", false},
 		{"1.2.3.4", true},
 		{"v1.2.3.4", true},
 		{"1.2.2147483648", false},
@@ -143,10 +143,10 @@ func TestOriginal(t *testing.T) {
 		"v1.2-beta.5",
 		"1.2.0-x.Y.0+metadata",
 		"v1.2.0-x.Y.0+metadata",
-		"1.2.0-x.Y.0+metadata-width-hypen",
-		"v1.2.0-x.Y.0+metadata-width-hypen",
-		"1.2.3-rc1-with-hypen",
-		"v1.2.3-rc1-with-hypen",
+		"1.2.0-x.Y.0+metadata-width-hyphen",
+		"v1.2.0-x.Y.0+metadata-width-hyphen",
+		"1.2.3-rc1-with-hyphen",
+		"v1.2.3-rc1-with-hyphen",
 	}
 
 	for _, tc := range tests {
@@ -202,10 +202,10 @@ func TestCoerceString(t *testing.T) {
 		{"v1.2-beta.5", "1.2.0-beta.5"},
 		{"1.2.0-x.Y.0+metadata", "1.2.0-x.Y.0+metadata"},
 		{"v1.2.0-x.Y.0+metadata", "1.2.0-x.Y.0+metadata"},
-		{"1.2.0-x.Y.0+metadata-width-hypen", "1.2.0-x.Y.0+metadata-width-hypen"},
-		{"v1.2.0-x.Y.0+metadata-width-hypen", "1.2.0-x.Y.0+metadata-width-hypen"},
-		{"1.2.3-rc1-with-hypen", "1.2.3-rc1-with-hypen"},
-		{"v1.2.3-rc1-with-hypen", "1.2.3-rc1-with-hypen"},
+		{"1.2.0-x.Y.0+metadata-width-hyphen", "1.2.0-x.Y.0+metadata-width-hyphen"},
+		{"v1.2.0-x.Y.0+metadata-width-hyphen", "1.2.0-x.Y.0+metadata-width-hyphen"},
+		{"1.2.3-rc1-with-hyphen", "1.2.3-rc1-with-hyphen"},
+		{"v1.2.3-rc1-with-hyphen", "1.2.3-rc1-with-hyphen"},
 	}
 
 	for _, tc := range tests {
@@ -563,12 +563,12 @@ func TestJsonUnmarshal(t *testing.T) {
 	ver := &Version{}
 	err := json.Unmarshal([]byte(fmt.Sprintf("%q", sVer)), ver)
 	if err != nil {
-		t.Errorf("Error unmarshaling version: %s", err)
+		t.Errorf("Error unmarshalling version: %s", err)
 	}
 	got := ver.String()
 	want := sVer
 	if got != want {
-		t.Errorf("Error unmarshaling unexpected object content: got=%q want=%q", got, want)
+		t.Errorf("Error unmarshalling unexpected object content: got=%q want=%q", got, want)
 	}
 }
 
@@ -598,13 +598,13 @@ func TestTextUnmarshal(t *testing.T) {
 
 	err := ver.UnmarshalText([]byte(sVer))
 	if err != nil {
-		t.Errorf("Error unmarshaling version: %s", err)
+		t.Errorf("Error unmarshalling version: %s", err)
 	}
 
 	got := ver.String()
 	want := sVer
 	if got != want {
-		t.Errorf("Error unmarshaling unexpected object content: got=%q want=%q", got, want)
+		t.Errorf("Error unmarshalling unexpected object content: got=%q want=%q", got, want)
 	}
 }
 


### PR DESCRIPTION
Typos were found by [typos](https://github.com/crate-ci/typos):

```
error: `hypen` should be `hyphen`
  --> .\version_test.go:35:32
   |
35 |   {"1.2.0-x.Y.0+metadata-width-hypen", false},
   |                                ^^^^^
   |
error: `hypen` should be `hyphen`
  --> .\version_test.go:36:33
   |
36 |   {"v1.2.0-x.Y.0+metadata-width-hypen", true},
   |                                 ^^^^^
   |
error: `hypen` should be `hyphen`
  --> .\version_test.go:37:20
   |
37 |   {"1.2.3-rc1-with-hypen", false},
   |                    ^^^^^
   |
error: `hypen` should be `hyphen`
  --> .\version_test.go:38:21
   |
38 |   {"v1.2.3-rc1-with-hypen", true},
   |                     ^^^^^
   |
error: `hypen` should be `hyphen`
  --> .\version_test.go:85:32
   |
85 |   {"1.2.0-x.Y.0+metadata-width-hypen", false},
   |                                ^^^^^
   |
error: `hypen` should be `hyphen`
  --> .\version_test.go:86:33
   |
86 |   {"v1.2.0-x.Y.0+metadata-width-hypen", false},
   |                                 ^^^^^
   |
error: `hypen` should be `hyphen`
  --> .\version_test.go:87:20
   |
87 |   {"1.2.3-rc1-with-hypen", false},
   |                    ^^^^^
   |
error: `hypen` should be `hyphen`
  --> .\version_test.go:88:21
   |
88 |   {"v1.2.3-rc1-with-hypen", false},
   |                     ^^^^^
   |
error: `hypen` should be `hyphen`
  --> .\version_test.go:146:31
    |
146 |   "1.2.0-x.Y.0+metadata-width-hypen",
    |                               ^^^^^
    |
error: `hypen` should be `hyphen`
  --> .\version_test.go:147:32
    |
147 |   "v1.2.0-x.Y.0+metadata-width-hypen",
    |                                ^^^^^
    |
error: `hypen` should be `hyphen`
  --> .\version_test.go:148:19
    |
148 |   "1.2.3-rc1-with-hypen",
    |                   ^^^^^
    |
error: `hypen` should be `hyphen`
  --> .\version_test.go:149:20
    |
149 |   "v1.2.3-rc1-with-hypen",
    |                    ^^^^^
    |
error: `hypen` should be `hyphen`
  --> .\version_test.go:205:32
    |
205 |   {"1.2.0-x.Y.0+metadata-width-hypen", "1.2.0-x.Y.0+metadata-width-hypen"},
    |                                ^^^^^
    |
error: `hypen` should be `hyphen`
  --> .\version_test.go:205:68
    |
205 |   {"1.2.0-x.Y.0+metadata-width-hypen", "1.2.0-x.Y.0+metadata-width-hypen"},
    |                                                                    ^^^^^
    |
error: `hypen` should be `hyphen`
  --> .\version_test.go:206:33
    |
206 |   {"v1.2.0-x.Y.0+metadata-width-hypen", "1.2.0-x.Y.0+metadata-width-hypen"},
    |                                 ^^^^^
    |
error: `hypen` should be `hyphen`
  --> .\version_test.go:206:69
    |
206 |   {"v1.2.0-x.Y.0+metadata-width-hypen", "1.2.0-x.Y.0+metadata-width-hypen"},
    |                                                                     ^^^^^
    |
error: `hypen` should be `hyphen`
  --> .\version_test.go:207:20
    |
207 |   {"1.2.3-rc1-with-hypen", "1.2.3-rc1-with-hypen"},
    |                    ^^^^^
    |
error: `hypen` should be `hyphen`
  --> .\version_test.go:207:44
    |
207 |   {"1.2.3-rc1-with-hypen", "1.2.3-rc1-with-hypen"},
    |                                            ^^^^^
    |
error: `hypen` should be `hyphen`
  --> .\version_test.go:208:21
    |
208 |   {"v1.2.3-rc1-with-hypen", "1.2.3-rc1-with-hypen"},
    |                     ^^^^^
    |
error: `hypen` should be `hyphen`
  --> .\version_test.go:208:45
    |
208 |   {"v1.2.3-rc1-with-hypen", "1.2.3-rc1-with-hypen"},
    |                                             ^^^^^
    |
error: `unmarshaling` should be `unmarshalling`
  --> .\version_test.go:566:19
    |
566 |   t.Errorf("Error unmarshaling version: %s", err)
    |                   ^^^^^^^^^^^^
    |
error: `unmarshaling` should be `unmarshalling`
  --> .\version_test.go:571:19
    |
571 |   t.Errorf("Error unmarshaling unexpected object content: got=%q want=%q", got, want)
    |                   ^^^^^^^^^^^^
    |
error: `unmarshaling` should be `unmarshalling`
  --> .\version_test.go:601:19
    |
601 |   t.Errorf("Error unmarshaling version: %s", err)
    |                   ^^^^^^^^^^^^
    |
error: `unmarshaling` should be `unmarshalling`
  --> .\version_test.go:607:19
    |
607 |   t.Errorf("Error unmarshaling unexpected object content: got=%q want=%q", got, want)
    |                   ^^^^^^^^^^^^
    |
error: `lentgh` should be `length`
  --> .\version.go:525:16
    |
525 |   // Since the lentgh of the parts can be different we need to create
    |                ^^^^^^
    |
error: `fo` should be `of`, `for`, `do`, `go`, `to`
  --> .\README.md:23:32
   |
23 | There are three major versions fo the `semver` package.
   |                                ^^
   |
error: `constrint` should be `constraint`
  --> .\constraints_test.go:686:35
    |
686 |    t.Errorf("expected string from constrint %q to parse as valid but got err: %s", tc.constraint, err)
    |                                   ^^^^^^^^^
    |
error: `unmarshaling` should be `unmarshalling`
  --> .\constraints_test.go:731:20
    |
731 |    t.Errorf("Error unmarshaling constraint: %s", err)
    |                    ^^^^^^^^^^^^
    |
error: `unmarshaling` should be `unmarshalling`
  --> .\constraints_test.go:760:20
    |
760 |    t.Errorf("Error unmarshaling constraints: %s", err)
    |                    ^^^^^^^^^^^^
    |
error: `unmarshaling` should be `unmarshalling`
  --> .\constraints_test.go:764:20
    |
764 |    t.Errorf("Error unmarshaling constraint, unexpected object content: got=%q want=%q", got, tc.want)
    |                    ^^^^^^^^^^^^
    |
error: `unmarshaling` should be `unmarshalling`
  --> .\constraints_test.go:767:63
    |
767 |   // Test that this works for JSON as well as text. When JSON unmarshaling
    |                                                               ^^^^^^^^^^^^
    |
error: `unmarshaling` should be `unmarshalling`
  --> .\constraints_test.go:771:20
    |
771 |    t.Errorf("Error unmarshaling constraints: %s", err)
    |                    ^^^^^^^^^^^^
    |
error: `unmarshaling` should be `unmarshalling`
  --> .\constraints_test.go:775:20
    |
775 |    t.Errorf("Error unmarshaling constraint, unexpected object content: got=%q want=%q", got, tc.want)
    |                    ^^^^^^^^^^^^
    |
error: `unmarshaling` should be `unmarshalling`
  --> .\CHANGELOG.md:21:35
   |
21 | - #190: Added text marshaling and unmarshaling
   |                                   ^^^^^^^^^^^^
   |
error: `appliaction` should be `application`
  --> .\CHANGELOG.md:133:56
    |
133 | - #72: Updated the docs to point to vert for a console appliaction
    |                                                        ^^^^^^^^^^^
    |
```