### PR TITLE
doc: hyphen range constraint without whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ These look like:
 * `1.2 - 1.4.5` which is equivalent to `>= 1.2 <= 1.4.5`
 * `2.3.4 - 4.5` which is equivalent to `>= 2.3.4 <= 4.5`
 
+Note that `1.2-1.4.5` without whitespace is parsed completely differently; it's
+parsed as a single constraint `1.2.0` with _prerelease_ `1.4.5`.
+
 ### Wildcards In Comparisons
 
 The `x`, `X`, and `*` characters can be used as a wildcard character. This works


### PR DESCRIPTION
I was a bit surprised that the following doesn't work as expected at first sight:

```go
package main

import (
	"github.com/Masterminds/semver/v3"
)

func main() {
	c, err := semver.NewConstraint("0.7.2-0.8.0")
	if err != nil {
		panic(err)
	}
	v, err := semver.NewVersion("0.7.25")
	if err != nil {
		panic(err)
	}
	println(c.Check(v))
}
```

then I realized that we need whitespace between:

```diff
-	c, err := semver.NewConstraint("0.7.2-0.8.0")
+ 	c, err := semver.NewConstraint("0.7.2 - 0.8.0")
```