### PR TITLE
allow prerelease matching

### DIFF
--- a/constraints_test.go
+++ b/constraints_test.go
@@ -125,6 +125,8 @@ func TestConstraintCheck(t *testing.T) {
 		{"*", "4.5.6", true},
 		{"*", "1.2.3-alpha.1", false},
 		{"*-0", "1.2.3-alpha.1", true},
+		{"*-alpha.*", "1.2.3-alpha.1", true},
+		{"*-alpha.*", "1.2.3-beta.1", false},
 		{"2.*", "1", false},
 		{"2.*", "3.4.5", false},
 		{"2.*", "2.1.1", true},


### PR DESCRIPTION
This change adds prerelease constraint *-alpha.* for matching prerelease in a version with the following format 1.2.3-alpha.1