### PR TITLE
Add new error when int parsing fails

### DIFF
--- a/version.go
+++ b/version.go
@@ -36,6 +36,10 @@ var (
 
 	// ErrInvalidPrerelease is returned when the pre-release is an invalid format
 	ErrInvalidPrerelease = errors.New("Invalid Prerelease string")
+
+	// ErrSegmentUnparsable is returned if a version segment cannot be parsed as
+	// an int.
+	ErrSegmentUnparsable = errors.New("Version segment unparsable")
 )
 
 // semVerRegex is the regular expression used to parse a semantic version.
@@ -170,13 +174,13 @@ func NewVersion(v string) (*Version, error) {
 	var err error
 	sv.major, err = strconv.ParseUint(m[1], 10, 64)
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing version segment: %s", err)
+		return nil, ErrSegmentUnparsable
 	}
 
 	if m[2] != "" {
 		sv.minor, err = strconv.ParseUint(strings.TrimPrefix(m[2], "."), 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("Error parsing version segment: %s", err)
+			return nil, ErrSegmentUnparsable
 		}
 	} else {
 		sv.minor = 0
@@ -185,7 +189,7 @@ func NewVersion(v string) (*Version, error) {
 	if m[3] != "" {
 		sv.patch, err = strconv.ParseUint(strings.TrimPrefix(m[3], "."), 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("Error parsing version segment: %s", err)
+			return nil, ErrSegmentUnparsable
 		}
 	} else {
 		sv.patch = 0

--- a/version_test.go
+++ b/version_test.go
@@ -3,7 +3,9 @@ package semver
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strconv"
 	"testing"
 )
 
@@ -158,6 +160,34 @@ func TestOriginal(t *testing.T) {
 		o := v.Original()
 		if o != tc {
 			t.Errorf("Error retrieving original. Expected '%s' but got '%v'", tc, v)
+		}
+	}
+}
+
+func TestErrors(t *testing.T) {
+	tests := map[string]error{
+		"1.3.2023080721291691443750": ErrSegmentUnparsable,
+		"1.2.3.4.5":                  ErrInvalidSemVer,
+		"":                           ErrInvalidSemVer,
+		"1.2.0+invalid_metadata":     ErrInvalidSemVer,
+	}
+	for v, e := range tests {
+		_, err := NewVersion(v)
+		if !errors.Is(err, e) {
+			t.Errorf("Expecting error: %s but got: %s, version %s", e, err, v)
+		}
+	}
+
+	strictTests := map[string]error{
+		"1.3.2023080721291691443750": strconv.ErrRange,
+		"1.2.3.4.5":                  ErrInvalidCharacters,
+		"":                           ErrEmptyString,
+		"1.2.0+invalid$metadata":     ErrInvalidMetadata,
+	}
+	for v, e := range strictTests {
+		_, err := StrictNewVersion(v)
+		if !errors.Is(err, e) {
+			t.Errorf("Expecting error: %s but got: %s, version: %s", e, err, v)
 		}
 	}
 }


### PR DESCRIPTION
It's hard to reason with errors when `strconv.ParseUint` fails as the returned error is untyped. This change introduces a new error that is returned if the int parsing fails.