### PR TITLE
Implemented binary marshalling/unmarshalling

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -245,3 +245,49 @@ func BenchmarkStrictNewVersionMetaDash(b *testing.B) {
 	b.ResetTimer()
 	benchStrictNewVersion("1.0.0-alpha.1+meta.data", b)
 }
+
+/* Marshalling benchmarks */
+
+func BenchmarkTextMarshal(b *testing.B) {
+	v := MustParse("1.0.0-alpha.1+meta.data")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = v.MarshalText()
+	}
+}
+
+func BenchmarkBinaryMarshal(b *testing.B) {
+	v := MustParse("1.0.0-alpha.1+meta.data")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = v.MarshalBinary()
+	}
+}
+
+func BenchmarkTextUnmarshal(b *testing.B) {
+	var v Version
+	text, err := MustParse("1.0.0-alpha.1+meta.data").MarshalText()
+	if err != nil {
+		panic(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = v.UnmarshalText(text)
+	}
+}
+
+func BenchmarkBinaryUnmarshal(b *testing.B) {
+	var v Version
+	data, err := MustParse("1.0.0-alpha.1+meta.data").MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = v.UnmarshalText(data)
+	}
+}


### PR DESCRIPTION
I had a similar issue raised by #192 

I want to use `semver.Version` in an [encoding/gob](https://pkg.go.dev/encoding/gob) serialized structure, so it needs to implement [encoding.BinaryMarshaler](https://pkg.go.dev/encoding#BinaryMarshaler) and [encoding.BinaryUnmarshaler](https://pkg.go.dev/encoding#BinaryUnmarshaler).

I decided to use the fact that it's specifically a binary encoding and used varints from "encoding/binary". This makes binary marshaling 11.2x faster and unmarshaling 8.9x faster than text-based operations.

If you don't like low-level (although tested and straightforward) code you can add this functionality based on text marshaling like so:

```go
func (v Version) MarshalBinary() ([]byte, error) {
	return v.MarshalText()
}

func (v *Version) UnmarshalBinary(data []byte) error {
	return v.UnmarshalText(data)
}
```
