### PR TITLE
docs: Correct wording about tilde range comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ back to the patch level comparison (see tilde below). For example,
 
 ### Tilde Range Comparisons (Patch)
 
-The tilde (`~`) comparison operator is for patch level ranges when a minor
-version is specified and major level changes when the minor number is missing.
+The tilde (`~`) comparison operator is for patch level ranges when the minor
+number is specified and minor level changes when the major number is specified.
 For example,
 
 * `~1.2.3` is equivalent to `>= 1.2.3, < 1.3.0`


### PR DESCRIPTION
The "major level changes when the minor number is missing" was incorrect.

------

This variant of the sentence is ambiguous, possibly incorrect, especially the second part of it:

https://github.com/Masterminds/semver/blob/1558ca3488226e3490894a145e831ad58a5ff958/README.md?plain=1#L187-L188

The tests also confirm it is not about major level changes but minor:

https://github.com/Masterminds/semver/blob/1558ca3488226e3490894a145e831ad58a5ff958/constraints_test.go#L383-L388

Unless, I'm completely confused myself :)
