### PR TITLE
fix: trim surrounding space in version and constraint parse

### DIFF
--- a/constraints.go
+++ b/constraints.go
@@ -39,6 +39,7 @@ var ErrTooManyConstraintGroups = fmt.Errorf("too many constraint groups (max %d)
 // NewConstraint returns a Constraints instance that a Version instance can
 // be checked against. If there is a parse error it will be returned.
 func NewConstraint(c string) (*Constraints, error) {
+	c = strings.TrimSpace(c)
 
 	if len(c) > MaxConstraintLen {
 		return nil, ErrConstraintTooLong

--- a/constraints_test.go
+++ b/constraints_test.go
@@ -1218,3 +1218,17 @@ func FuzzNewConstraint(f *testing.F) {
 		_, _ = NewConstraint(a)
 	})
 }
+
+func TestNewConstraintTrimSpace(t *testing.T) {
+	c, err := NewConstraint(" >=1.0.0 ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, err := NewVersion("1.2.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !c.Check(v) {
+		t.Fatal("expected match")
+	}
+}

--- a/version.go
+++ b/version.go
@@ -96,6 +96,7 @@ const (
 // If you want to coerce a version such as 1 or 1.2 and parse it as the 1.x
 // releases of semver did, use the NewVersion() function.
 func StrictNewVersion(v string) (*Version, error) {
+	v = strings.TrimSpace(v)
 	// Parsing here does not use RegEx in order to increase performance and reduce
 	// allocations.
 
@@ -174,6 +175,7 @@ func StrictNewVersion(v string) (*Version, error) {
 // attempts to convert it to SemVer. If you want  to validate it was a strict
 // semantic version at parse time see StrictNewVersion().
 func NewVersion(v string) (*Version, error) {
+	v = strings.TrimSpace(v)
 	if len(v) > MaxVersionLen {
 		return nil, ErrVersionTooLong
 	}

--- a/version_test.go
+++ b/version_test.go
@@ -1087,3 +1087,20 @@ func TestNewVersionTooLong(t *testing.T) {
 		t.Errorf("StrictNewVersion: expected ErrVersionTooLong, got: %v", err)
 	}
 }
+
+func TestNewVersionTrimSpace(t *testing.T) {
+	v, err := NewVersion(" 1.2.3 ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.String() != "1.2.3" {
+		t.Fatalf("got %s", v)
+	}
+	v, err = StrictNewVersion(" 2.0.0 ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.String() != "2.0.0" {
+		t.Fatalf("strict got %s", v)
+	}
+}


### PR DESCRIPTION
## What

`NewVersion`, `StrictNewVersion`, and `NewConstraint` now trim leading/trailing whitespace before parsing.

## Why

Config files and CLI flags often leave padded values (`" 1.2.3 "`, `" >=1.0.0 "`). Those failed parse even though the non-space content was valid.

## Test

- `TestNewVersionTrimSpace`
- `TestNewConstraintTrimSpace`