### PR TITLE
Compare oversized numeric prerelease identifiers numerically

### DIFF
--- a/version.go
+++ b/version.go
@@ -762,21 +762,31 @@ func comparePrePart(s, o string) int {
 
 	oi, n1 := strconv.ParseUint(o, 10, 64)
 	si, n2 := strconv.ParseUint(s, 10, 64)
+	oNumeric := n1 == nil || errors.Is(n1, strconv.ErrRange)
+	sNumeric := n2 == nil || errors.Is(n2, strconv.ErrRange)
 
 	// The case where both are strings compare the strings
-	if n1 != nil && n2 != nil {
+	if !oNumeric && !sNumeric {
 		if s > o {
 			return 1
 		}
 		return -1
-	} else if n1 != nil {
+	} else if !oNumeric {
 		// o is a string and s is a number
 		return -1
-	} else if n2 != nil {
+	} else if !sNumeric {
 		// s is a string and o is a number
 		return 1
 	}
 	// Both are numbers
+	if n1 != nil || n2 != nil {
+		// Valid numeric identifiers have no leading zeroes. Compare their
+		// lengths and digits when either identifier exceeds uint64.
+		if len(s) != len(o) {
+			return compareSegment(uint64(len(s)), uint64(len(o)))
+		}
+		return strings.Compare(s, o)
+	}
 	if si > oi {
 		return 1
 	}

--- a/version_test.go
+++ b/version_test.go
@@ -1018,6 +1018,29 @@ func TestOriginalVPrefix(t *testing.T) {
 	}
 }
 
+func TestCompareLargeNumericPrerelease(t *testing.T) {
+	for _, tc := range [][2]string{
+		{"99999999999999999999", "100000000000000000000"},
+		{"18446744073709551616", "0alpha"},
+		{"rc.99999999999999999999", "rc.100000000000000000000"},
+		{"18446744073709551615", "18446744073709551616"},
+	} {
+		t.Run(tc[0]+"_"+tc[1], func(t *testing.T) {
+			left, err := StrictNewVersion("1.0.0-" + tc[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			right, err := StrictNewVersion("1.0.0-" + tc[1])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if left.Compare(right) != -1 || right.Compare(left) != 1 {
+				t.Fatalf("expected %s < %s", left, right)
+			}
+		})
+	}
+}
+
 func TestJsonMarshal(t *testing.T) {
 	sVer := "1.1.1"
 	x, err := StrictNewVersion(sVer)


### PR DESCRIPTION
Valid numeric prerelease identifiers can exceed `uint64`. `Compare` currently treats those identifiers as alphanumeric after `strconv.ParseUint` returns a range error, producing incorrect ordering both against other large numbers and against alphanumeric identifiers.

Distinguish range errors from nonnumeric input. Keep the existing numeric fast path; for larger numeric identifiers compare digit counts and then digits, as valid numeric identifiers have no leading zeroes. Regressions cover both comparison directions, nested prerelease identifiers, the `uint64` boundary, and numeric-versus-alphanumeric precedence.

This follows [SemVer precedence rule 11](https://semver.org/#spec-item-11). The large-number ordering cases fail on the base revision.

Validation: `go test -race ./...`, `go vet ./...`, gofmt and `git diff --check` pass on Go 1.27.1 / macOS arm64.

Disclosure: Codex implemented and tested this change under the submitting account's authorization.
