### PR TITLE
Accept caret constraints with a wildcard major

### DIFF
--- a/constraints.go
+++ b/constraints.go
@@ -558,6 +558,11 @@ func constraintCaret(v *Version, c *constraint, includePre bool) (bool, error) {
 		return false, fmt.Errorf("%q is less than %q", v, c.orig)
 	}
 
+	// A wildcard major has no upper bound, unlike ^0 or ^0.0.
+	if c.dirty && !c.minorDirty && !c.patchDirty {
+		return true, nil
+	}
+
 	var eq bool
 
 	// ^ when the major > 0 is >=x.y.z < x+1

--- a/constraints_test.go
+++ b/constraints_test.go
@@ -9,6 +9,33 @@ import (
 	"testing"
 )
 
+func TestCaretMajorWildcard(t *testing.T) {
+	for _, text := range []string{"^*", "^x", "^X", "^*.*", "^x.x.x"} {
+		t.Run(text, func(t *testing.T) {
+			constraint, err := NewConstraint(text)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, version := range []string{"0.0.0", "0.1.0", "1.0.0", "9.8.7"} {
+				v := MustParse(version)
+				valid, reasons := constraint.Validate(v)
+				if !constraint.Check(v) || !valid || len(reasons) != 0 {
+					t.Errorf("%s should satisfy %s: %v", version, text, reasons)
+				}
+			}
+			pre := MustParse("1.0.0-alpha")
+			if constraint.Check(pre) {
+				t.Error("prerelease should be excluded by default")
+			}
+			constraint.IncludePrerelease = true
+			valid, reasons := constraint.Validate(pre)
+			if !constraint.Check(pre) || !valid || len(reasons) != 0 {
+				t.Errorf("explicitly included prerelease should satisfy %s: %v", text, reasons)
+			}
+		})
+	}
+}
+
 func TestParseConstraint(t *testing.T) {
 	tests := []struct {
 		in  string


### PR DESCRIPTION
`^*` is documented in the caret implementation as accepting any version, but currently rejects `0.1.0`, `1.0.0`, and other releases because its wildcard major is treated as a concrete zero.

After the existing prerelease and lower-bound checks, accept caret constraints with a wildcard major. Concrete `^0` and `^0.0` ranges continue through their existing bounds checks. Regressions cover `*`, `x`, `X`, multi-segment wildcards, both `Check` and `Validate`, and opt-in prerelease matching; all five wildcard groups fail on the base revision.

Validation: `go test -race ./...`, `go vet ./...`, gofmt and `git diff --check` pass on Go 1.27.1 / macOS arm64.

Disclosure: Codex implemented and tested this change under the submitting account's authorization.
